### PR TITLE
Use glob patterns in native import whitelists

### DIFF
--- a/checker/whitelists/python-3.12.10-atls/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-atls/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torchaudio-2.7.0+cpu-cp312-cp312-manylinux_2_28_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-atls/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-atls/macosx-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0-cp312-none-macosx_11_0_arm64.whl": {

--- a/checker/whitelists/python-3.12.10-h5ad/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/linux-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "scipy-1.*.whl": {

--- a/checker/whitelists/python-3.12.10-h5ad/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numba-0.*.whl": {

--- a/checker/whitelists/python-3.12.10-h5ad/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/macosx-aarch64.json
@@ -1,8 +1,8 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
-  "numba-0.*-macosx_11_0_arm64.whl": {
+  "numba-0.*-macosx_*_arm64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
   "scipy-1.*-macosx_12_0_arm64.whl": {

--- a/checker/whitelists/python-3.12.10-h5ad/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/macosx-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numba-0.*-macosx_10_15_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-h5ad/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/windows-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "matplotlib-3.*-cp312-cp312-win_amd64.whl": {

--- a/checker/whitelists/python-3.12.10-parapred/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10-parapred/linux-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0+cpu-cp312-cp312-manylinux_2_28_aarch64.whl": {

--- a/checker/whitelists/python-3.12.10-parapred/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-parapred/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0+cpu-cp312-cp312-manylinux_2_28_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-parapred/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-parapred/macosx-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0-cp312-none-macosx_11_0_arm64.whl": {

--- a/checker/whitelists/python-3.12.10-parapred/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-parapred/windows-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0+cpu-cp312-cp312-win_amd64.whl": {

--- a/checker/whitelists/python-3.12.10-rapids/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10-rapids/linux-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0+cpu-cp312-cp312-manylinux_2_28_aarch64.whl": {

--- a/checker/whitelists/python-3.12.10-rapids/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-rapids/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "cuproj_cu12-25.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-rapids/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-rapids/macosx-aarch64.json
@@ -1,8 +1,8 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
-  "numba-0.*-macosx_11_0_arm64.whl": {
+  "numba-0.*-macosx_*_arm64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
   "scipy-1.*-macosx_12_0_arm64.whl": {

--- a/checker/whitelists/python-3.12.10-rapids/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10-rapids/macosx-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numba-0.*-macosx_10_15_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-rapids/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-rapids/windows-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numba-0.*-win_amd64.whl": {
@@ -9,7 +9,7 @@
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
   },
-  "rpy2_rinterface-3.6.4-cp312-cp312-win_amd64.whl": {
+  "rpy2_rinterface-3.*.whl": {
     "_rinterface_cffi_api": "DLL load failed while importing _rinterface_cffi_api: The specified module could not be found."
   },
   "torch-2.7.0+cpu-cp312-cp312-win_amd64.whl": {

--- a/checker/whitelists/python-3.12.10-sccoda/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/linux-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": {

--- a/checker/whitelists/python-3.12.10-sccoda/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-sccoda/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/linux-x64.json
@@ -9,10 +9,7 @@
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
   },
-  "tensorflow-2.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": {
-    "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
-  },
-  "tensorflow-2.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
   }
 }

--- a/checker/whitelists/python-3.12.10-sccoda/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/macosx-aarch64.json
@@ -1,18 +1,15 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl": {
     "numpy.core._umath_tests": "cannot load _umath_tests module"
   },
-  "numba-0.*-macosx_11_0_arm64.whl": {
+  "numba-0.*-macosx_*_arm64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "'/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.dylib' (no such file)"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "Reason: tried: '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.dylib' ("
+  "rpy2_rinterface-3.*.whl": {
+    "_rinterface_cffi_api": "'/Library/Frameworks/R.framework/Versions/"
   },
   "scipy-1.*-macosx_12_0_arm64.whl": {
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",

--- a/checker/whitelists/python-3.12.10-sccoda/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/macosx-aarch64.json
@@ -19,7 +19,7 @@
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
   },
-  "tensorflow-2.20.0-cp312-cp312-macosx_12_0_arm64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper",
     "tensorflow.lite.python._pywrap_tensorflow_lite_metrics_wrapper": "generic_type: type \"MetricsWrapper\" is already registered"
   }

--- a/checker/whitelists/python-3.12.10-sccoda/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/macosx-x64.json
@@ -22,7 +22,7 @@
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
   },
-  "tensorflow-2.16.2-cp312-cp312-macosx_10_15_x86_64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
   }
 }

--- a/checker/whitelists/python-3.12.10-sccoda/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/macosx-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "ml_dtypes-0.3.2-cp312-cp312-macosx_10_9_universal2.whl": {
@@ -11,10 +11,7 @@
   "numba-0.*-macosx_10_15_x86_64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "symbol not found in flat namespace '_R_BaseEnv'"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-macosx_10_13_universal2.whl": {
+  "rpy2_rinterface-3.*.whl": {
     "_rinterface_cffi_api": "symbol not found in flat namespace '_R_BaseEnv'"
   },
   "scipy-1.*-macosx_14_0_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
@@ -25,7 +25,7 @@
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
   },
-  "tensorflow-2.20.0-cp312-cp312-win_amd64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.lite.python._pywrap_tensorflow_lite_metrics_wrapper": "generic_type: type \"MetricsWrapper\" is already registered"
   }
 }

--- a/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
@@ -15,14 +15,11 @@
   "numba-0.*-win_amd64.whl": {
     "numba.np.ufunc.tbbpool": "DLL load failed while importing tbbpool: The specified module could not be found"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-win_amd64.whl": {
+  "rpy2_rinterface-3.*.whl": {
     "_rinterface_cffi_api": "DLL load failed while importing _rinterface_cffi_api: The specified module could not be found"
   },
-  "charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-win_amd64.whl": {
-    "_rinterface_cffi_api": "DLL load failed while importing _rinterface_cffi_api: The specified module could not be found."
   },
   "scipy-1.*-win_amd64.whl": {
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",

--- a/checker/whitelists/python-3.12.10/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10/linux-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "torch-2.7.0+cpu-cp312-cp312-manylinux_2_28_aarch64.whl": {

--- a/checker/whitelists/python-3.12.10/linux-x64.json
+++ b/checker/whitelists/python-3.12.10/linux-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10/linux-x64.json
+++ b/checker/whitelists/python-3.12.10/linux-x64.json
@@ -60,10 +60,7 @@
   "torch-2.9.1+cpu-cp312-cp312-manylinux_2_28_x86_64.whl": {
     "functorch._C": "initialization failed"
   },
-  "tensorflow-2.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": {
-    "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
-  },
-  "tensorflow-2.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
   }
 }

--- a/checker/whitelists/python-3.12.10/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10/macosx-aarch64.json
@@ -1,15 +1,12 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
-  "numba-0.*-macosx_11_0_arm64.whl": {
+  "numba-0.*-macosx_*_arm64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "'/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.dylib' (no such file)"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "Reason: tried: '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.dylib' ("
+  "rpy2_rinterface-3.*.whl": {
+    "_rinterface_cffi_api": "'/Library/Frameworks/R.framework/Versions/"
   },
   "scipy-1.*-macosx_12_0_arm64.whl": {
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",

--- a/checker/whitelists/python-3.12.10/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10/macosx-aarch64.json
@@ -32,7 +32,7 @@
     "torio.lib.libtorio_ffmpeg5": "Reason: no LC_RPATH's found",
     "torio.lib.libtorio_ffmpeg6": "Reason: no LC_RPATH's found"
   },
-  "tensorflow-2.20.0-cp312-cp312-macosx_12_0_arm64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper",
     "tensorflow.lite.python._pywrap_tensorflow_lite_metrics_wrapper": "generic_type: type \"MetricsWrapper\" is already registered"
   }

--- a/checker/whitelists/python-3.12.10/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10/macosx-x64.json
@@ -29,7 +29,7 @@
   "torch-2.2.2-cp312-none-macosx_10_9_x86_64.whl": {
     "functorch._C": "initialization failed"
   },
-  "tensorflow-2.16.2-cp312-cp312-macosx_10_15_x86_64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.compiler.tf2xla.ops._xla_ops": "ALREADY_EXISTS: Op with name XlaBroadcastHelper"
   }
 }

--- a/checker/whitelists/python-3.12.10/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10/macosx-x64.json
@@ -1,5 +1,5 @@
 {
-  "charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "ml_dtypes-0.3.2-cp312-cp312-macosx_10_9_universal2.whl": {
@@ -11,10 +11,7 @@
   "numba-0.*-macosx_10_15_x86_64.whl": {
     "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-macosx_10_13_universal2.whl": {
-    "_rinterface_cffi_api": "symbol not found in flat namespace '_R_BaseEnv'"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-macosx_10_13_universal2.whl": {
+  "rpy2_rinterface-3.*.whl": {
     "_rinterface_cffi_api": "symbol not found in flat namespace '_R_BaseEnv'"
   },
   "scipy-1.*-macosx_10_13_x86_64.whl": {

--- a/checker/whitelists/python-3.12.10/windows-x64.json
+++ b/checker/whitelists/python-3.12.10/windows-x64.json
@@ -28,7 +28,7 @@
   "torch-2.9.1+cpu-cp312-cp312-win_amd64.whl": {
     "functorch._C": "initialization failed"
   },
-  "tensorflow-2.20.0-cp312-cp312-win_amd64.whl": {
+  "tensorflow-2.*.whl": {
     "tensorflow.lite.python._pywrap_tensorflow_lite_metrics_wrapper": "generic_type: type \"MetricsWrapper\" is already registered"
   },
   "torchaudio-2.7.0+cpu-cp312-cp312-win_amd64.whl": {

--- a/checker/whitelists/python-3.12.10/windows-x64.json
+++ b/checker/whitelists/python-3.12.10/windows-x64.json
@@ -12,14 +12,11 @@
   "numba-0.*-win_amd64.whl": {
     "numba.np.ufunc.tbbpool": "DLL load failed while importing tbbpool: The specified module could not be found"
   },
-  "rpy2_rinterface-3.6.3-cp312-cp312-win_amd64.whl": {
+  "rpy2_rinterface-3.*.whl": {
     "_rinterface_cffi_api": "DLL load failed while importing _rinterface_cffi_api: The specified module could not be found"
   },
-  "charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl": {
+  "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
-  },
-  "rpy2_rinterface-3.6.4-cp312-cp312-win_amd64.whl": {
-    "_rinterface_cffi_api": "DLL load failed while importing _rinterface_cffi_api: The specified module could not be found."
   },
   "scipy-1.*-win_amd64.whl": {
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",


### PR DESCRIPTION
## Summary
- Replace exact version strings with glob patterns for `charset_normalizer`, `rpy2_rinterface`, and `numba` across all 26 whitelist files
- Merges duplicate `rpy2_rinterface` entries (3.6.3 + 3.6.4) into single `rpy2_rinterface-3.*.whl` glob
- Broadens `numba` macOS arm64 pattern from `macosx_11_0` to `macosx_*` to match new wheel targeting `macosx_12_0`
- Follows the approach already used for `scipy-1.*.whl`, `numba-0.*-win_amd64.whl`, etc.

Fixes native import checker failures caused by dependency version bumps (charset_normalizer 3.4.5→3.4.7, rpy2 3.6.4→3.6.6, numba macosx_11→macosx_12).

## Test plan
- [ ] CI prebuild jobs pass on all platforms (linux-x64, linux-aarch64, macosx-x64, macosx-aarch64, windows-x64)
- [ ] No new "unused whitelist entries" warnings