### PR TITLE
Add python-3.12.10-scientific-slim runenv variant

### DIFF
--- a/.changeset/scientific-slim-variant.md
+++ b/.changeset/scientific-slim-variant.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': patch
+'@platforma-open/milaboratories.runenv-python-3': minor
+---
+
+Add `python-3.12.10-scientific-slim` runenv variant bundling only `polars-lts-cpu`, `numpy`, `scipy`, and `pyarrow`. Intended for blocks with tabular/scientific Python stacks that do not need the full ML toolchain (TensorFlow, torch, transformers, etc.) shipped by the base `3.12.10` runenv. Bundled size is ~100 MB vs. the base runenv's ~2.5 GB.

--- a/catalogue/package.json
+++ b/catalogue/package.json
@@ -29,6 +29,9 @@
       },
       "3.12.10-parapred": {
         "reference": "@platforma-open/milaboratories.runenv-python-3.12.10-parapred/dist/tengo/software/main.sw.json"
+      },
+      "3.12.10-scientific-slim": {
+        "reference": "@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim/dist/tengo/software/main.sw.json"
       }
     }
   },
@@ -42,7 +45,8 @@
     "@platforma-open/milaboratories.runenv-python-3.12.10-sccoda": "workspace:*",
     "@platforma-open/milaboratories.runenv-python-3.12.10-rapids": "workspace:*",
     "@platforma-open/milaboratories.runenv-python-3.12.10-h5ad": "workspace:*",
-    "@platforma-open/milaboratories.runenv-python-3.12.10-parapred": "workspace:*"
+    "@platforma-open/milaboratories.runenv-python-3.12.10-parapred": "workspace:*",
+    "@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim": "workspace:*"
   },
   "devDependencies": {
     "@platforma-sdk/package-builder": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda':
         specifier: workspace:*
         version: link:../python-3.12.10-sccoda
+      '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim':
+        specifier: workspace:*
+        version: link:../python-3.12.10-scientific-slim
     devDependencies:
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
@@ -155,6 +158,18 @@ importers:
         version: 4.20.6
 
   python-3.12.10-sccoda:
+    devDependencies:
+      '@platforma-sdk/package-builder':
+        specifier: 'catalog:'
+        version: 3.10.7
+      runenv-python-builder:
+        specifier: workspace:*
+        version: link:../builder
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.6
+
+  python-3.12.10-scientific-slim:
     devDependencies:
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
@@ -1528,6 +1543,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - python-3.12.10-rapids
   - python-3.12.10-h5ad
   - python-3.12.10-parapred
+  - python-3.12.10-scientific-slim
   - catalogue
 
 catalog:

--- a/python-3.12.10-scientific-slim/config.json
+++ b/python-3.12.10-scientific-slim/config.json
@@ -1,0 +1,12 @@
+{
+  "packages": {
+    "dependencies": [
+      "polars-lts-cpu==1.33.1",
+      "numpy==2.2.6",
+      "scipy==1.15.3",
+      "pyarrow==21.0.0"
+    ],
+    "skip": {},
+    "platformSpecific": {}
+  }
+}

--- a/python-3.12.10-scientific-slim/package.json
+++ b/python-3.12.10-scientific-slim/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim",
+  "version": "1.0.0",
+  "description": "Python 3.12.10 run environment bundling polars-lts-cpu, numpy, scipy, and pyarrow for scientific/tabular workloads",
+  "scripts": {
+    "cleanup": "rm -rf ./pkg-*.tgz ./pydist ./dist/ ./build/",
+    "reset": "pnpm run cleanup && rm -rf ./node_modules ./.turbo",
+    "build": "pl-py-builder",
+    "after-prebuild": "pl-pkg publish packages",
+    "before-publish": "pl-pkg prepublish"
+  },
+  "files": [
+    "dist/"
+  ],
+  "block-software": {
+    "entrypoints": {
+      "main": {
+        "environment": {
+          "artifact": {
+            "type": "environment",
+            "runtime": "python",
+            "registry": "platforma-open",
+            "python-version": "3.12.10",
+            "roots": {
+              "linux-x64": "./pydist/linux-x64",
+              "linux-aarch64": "./pydist/linux-aarch64",
+              "macosx-x64": "./pydist/macosx-x64",
+              "macosx-aarch64": "./pydist/macosx-aarch64",
+              "windows-x64": "./pydist/windows-x64"
+            },
+            "binDir": "bin"
+          }
+        }
+      }
+    }
+  },
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "@platforma-sdk/package-builder": "catalog:",
+    "runenv-python-builder": "workspace:*",
+    "tsx": "catalog:"
+  }
+}


### PR DESCRIPTION
## Summary
- New `python-3.12.10-scientific-slim` runenv variant bundling `polars-lts-cpu==1.33.1`, `numpy==2.2.6`, `scipy==1.15.3`, and `pyarrow==21.0.0`.
- Registered in `pnpm-workspace.yaml` and the `catalogue` package's entrypoints/deps.
- Changeset: `patch` on the new variant, `minor` on the catalogue package (new entrypoint added).

## Motivation
[`platforma-open/titeseq-analysis`](https://github.com/platforma-open/titeseq-analysis) CI currently fails from disk exhaustion on `ubuntu-latest` while extracting the ~800 MB TensorFlow wheel shipped by the base `3.12.10` runenv (`~2.5 GB` total across 36 ML packages). That block does pure Hill-equation fitting against MiXCR output — it does not use TF, torch, cudf, transformers, etc. This slim variant ships ~100 MB of wheels that match titeseq's existing `software/src/requirements.txt` pins exactly, so runtime pip can resolve them under the hardcoded `--no-index --find-links={runenv}/packages/` flags in `install-deps.tpl.tengo`.

## Variant layout
```
python-3.12.10-scientific-slim/
├── package.json  (mirrors python-3.12.10-h5ad/package.json structure; version 1.0.0)
└── config.json   (4 pinned deps, same schema as h5ad/sccoda)
```

## Notes
- No changes to existing variants or the base runenv.
- Future consumers with identical scipy/numpy/polars/pyarrow stacks could migrate off the heavy base (e.g., `paratope-clustering`, `cell-type-annotation`, `differential-expression` — each shares the same runenv and will hit the same wall once they add real integration tests).