### PR TITLE
Add scientific-slim to build matrix (fix post-merge publish)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,13 @@ jobs:
           {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-parapred"},
           {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-parapred"},
           {"os":"macos-14-large", "arch":"amd64", "selector":"./python-3.12.10-parapred"},
-          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-parapred"}
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-parapred"},
+
+          {"os":"ubuntu-large-arm64", "arch":"arm64", "selector":"./python-3.12.10-scientific-slim"},
+          {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"},
+          {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-scientific-slim"},
+          {"os":"macos-14-large", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"},
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"}
         ]
 
       sign-binaries: |


### PR DESCRIPTION
## Summary
Adds the 5-platform row set for `python-3.12.10-scientific-slim` to `.github/workflows/build.yaml`'s `pre-calculated-task-list`.

## Why
[PR #59](https://github.com/platforma-open/runenv-python-3/pull/59) introduced the scientific-slim variant and registered it in `catalogue/package.json` as a published entrypoint, but did not add matching rows to the CI matrix. Post-merge, [run 24843373584](https://github.com/platforma-open/runenv-python-3/actions/runs/24843373584/job/72730961303) failed at the `unified (build publish)` step with:

```
::error::Empty 'name' input. Specify artifact name
::error::No artifacts were restored by the action. Is 'name'/'pattern' input correct?
```

The publish job enumerates variants via the catalogue metapackage's workspace dependencies and tries to download each variant's prebuild artifact. scientific-slim had no prebuild job → no artifact → empty name.

The pending changeset for the scientific-slim variant is still sitting on `main` waiting for a successful release — this PR unblocks it.

## Scope
One-line change + 4 sibling matrix rows. No version/content changes to any package.
