### PR TITLE
chore: bump polars-pf to 1.1.27

### DIFF
--- a/.changeset/bump-polars-pf-1-1-27.md
+++ b/.changeset/bump-polars-pf-1-1-27.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Bump `polars-pf` from 1.1.26 to 1.1.27 in the `python-3.12.10` runenv.

--- a/.changeset/bump-polars-pf.md
+++ b/.changeset/bump-polars-pf.md
@@ -1,6 +1,0 @@
----
-'@platforma-open/milaboratories.runenv-python-3.12.10': patch
-'@platforma-open/milaboratories.runenv-python-3': patch
----
-
-Bump `polars-pf` from 1.1.25 to 1.1.26 in the `python-3.12.10` runenv.

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.26",
+      "polars-pf==1.1.27",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
## Summary
- Bump `polars-pf` from 1.1.26 to 1.1.27 in the `python-3.12.10` runenv
- Add changeset (patch bump)

## Test plan
- [ ] CI build passes