### PR TITLE
chore: bump polars-pf to 1.1.31 in python-3.12.10 runenv

### DIFF
--- a/.changeset/bump-polars-pf-1-1-31.md
+++ b/.changeset/bump-polars-pf-1-1-31.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Bump `polars-pf` from 1.1.27 to 1.1.31 in the `python-3.12.10` runenv.

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.27",
+      "polars-pf==1.1.31",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
Bump `polars-pf` from 1.1.27 to 1.1.31 in the `python-3.12.10` runenv.