### PR TITLE
feat: add biopython 1.87 to scientific-slim runenv

### DIFF
--- a/.changeset/scientific-slim-add-biopython.md
+++ b/.changeset/scientific-slim-add-biopython.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': minor
+---
+
+Add biopython 1.87 to the scientific-slim runenv. Enables blocks like sequence-properties to drop their per-block biopython bundling and rely on the shared runenv.

--- a/python-3.12.10-scientific-slim/config.json
+++ b/python-3.12.10-scientific-slim/config.json
@@ -4,7 +4,8 @@
       "polars-lts-cpu==1.33.1",
       "numpy==2.2.6",
       "scipy==1.15.3",
-      "pyarrow==21.0.0"
+      "pyarrow==21.0.0",
+      "biopython==1.87"
     ],
     "skip": {},
     "platformSpecific": {}

--- a/python-3.12.10-scientific-slim/package.json
+++ b/python-3.12.10-scientific-slim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim",
   "version": "1.0.1",
-  "description": "Python 3.12.10 run environment bundling polars-lts-cpu, numpy, scipy, and pyarrow for scientific/tabular workloads",
+  "description": "Python 3.12.10 run environment bundling polars-lts-cpu, numpy, scipy, pyarrow, and biopython for scientific/tabular workloads",
   "scripts": {
     "cleanup": "rm -rf ./pkg-*.tgz ./pydist ./dist/ ./build/",
     "reset": "pnpm run cleanup && rm -rf ./node_modules ./.turbo",


### PR DESCRIPTION
## Summary

- Adds `biopython==1.87` to `python-3.12.10-scientific-slim/config.json`.
- Updates the variant description to reflect the new dependency.
- Adds a `minor` changeset for `@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim`.

## Why

The `sequence-properties` block currently bundles biopython per-block via pip + `requirements.txt`. Promoting biopython into the shared scientific-slim runenv lets that block (and future ones) drop the per-block bundle and pull biopython from the shared environment instead.

`biopython==1.87` matches the version already pinned in `blocks/sequence-properties/software/uv.lock`.

## Notes

- No version bump in `package.json` — changesets handle that on merge.
- No `checker/whitelists/python-3.12.10-scientific-slim/` added. Builder treats a missing whitelist as non-fatal (`builder/src/build.ts:478-482`); biopython 1.87 on cpython 3.12 has a small native footprint and is expected to import cleanly across all five platforms. If CI flags an import on some platform, the checker emits a snippet to copy in.
- Block-side switch (sequence-properties → scientific-slim) is a follow-up PR after this publishes.
