### PR TITLE
PFrames update

### DIFF
--- a/.changeset/petite-teams-notice.md
+++ b/.changeset/petite-teams-notice.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames update

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.31",
+      "polars-pf==1.1.37",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps `polars-pf` from `1.1.31` to `1.1.37` in the Python 3.12.10 environment's dependency list and adds the corresponding changeset entry.

- `python-3.12.10/config.json`: `polars-pf` updated from `1.1.31` → `1.1.37`; all other pinned versions remain unchanged.
- `.changeset/petite-teams-notice.md`: patch-level changeset entry added to track the release.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A straightforward dependency version bump with a matching changeset entry — safe to merge.

The change is a single-line version pin update for polars-pf (1.1.31 → 1.1.37) in one environment config. The other Python environment configs in the repo do not include polars-pf, so no sibling files are out of sync. The changeset entry is correctly scoped as a patch release.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/petite-teams-notice.md | Changeset entry describing the polars-pf version bump as a patch release for the python-3.12.10 package. |
| python-3.12.10/config.json | Bumps polars-pf from 1.1.31 to 1.1.37; no other changes to the dependency list. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: PFrames update] --> B[python-3.12.10/config.json]
    B --> C[polars-pf 1.1.31 → 1.1.37]
    A --> D[.changeset/petite-teams-notice.md]
    D --> E[patch release entry]
    C --> F[Other environments\npython-3.12.10-atls\npython-3.12.10-h5ad\npython-3.12.10-scientific-slim\netc.]
    F -->|polars-pf not present| G[No changes needed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames update"](https://github.com/platforma-open/runenv-python-3/commit/74702b3f18ed077d5f234dde423be57c061a4965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33803981)</sub>

<!-- /greptile_comment -->