### PR TITLE
Fix checker after PFrames bump

### DIFF
--- a/.changeset/tidy-sheep-see.md
+++ b/.changeset/tidy-sheep-see.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Fix checker after PFrames bump

--- a/checker/whitelists/python-3.12.10/linux-x64.json
+++ b/checker/whitelists/python-3.12.10/linux-x64.json
@@ -2,21 +2,7 @@
   "charset_normalizer-3.*.whl": {
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
-  "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl": {
-    "cupy.cuda.cufft": "libcufft.so.11: cannot open shared object file: No such file or directory",
-    "cupy.cuda.jitify": "libnvrtc.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cublas": "libcublas.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cudnn": "libcudnn.so.8: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.curand": "libcurand.so.10: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cusolver": "libcusolver.so.11: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cusparse": "libcusparse.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cutensor": "libcutensor.so.2: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.nccl": "libnccl.so.2: cannot open shared object file: No such file or directory",
-    "cupyx.cudnn": "libcudnn.so.8: cannot open shared object file: No such file or directory",
-    "cupyx.cusolver": "libcusolver.so.11: cannot open shared object file: No such file or directory",
-    "cupyx.cutensor": "libcutensor.so.2: cannot open shared object file: No such file or directory"
-  },
-  "cupy_cuda12x-14.0.1-cp312-cp312-manylinux2014_x86_64.whl": {
+  "cupy_cuda12x-*.whl": {
     "cupy.cuda.cufft": "libcufft.so.11: cannot open shared object file: No such file or directory",
     "cupy.cuda.jitify": "libnvrtc.so.12: cannot open shared object file: No such file or directory",
     "cupy_backends.cuda.libs.cublas": "libcublas.so.12: cannot open shared object file: No such file or directory",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the python-3.12.10 linux-x64 import-checker whitelist to match a PFrames package bump: cupy whitelist entries for versions 13.6.0 and 14.0.1 are replaced by a 14.1.0 entry, and new suppressions are added for `librmm_cu12` 25.6.0, `libcudf_cu12` 25.6.0, and `torch` 2.9.1+cpu.

- Removes two stale cupy version blocks (13.6.0 and 14.0.1) and introduces the corresponding 14.1.0 block with the same expected shared-library errors.
- The 14.1.0 block omits the `cudnn` suppressions that were present in 14.0.1; worth confirming this is intentional and that those modules now import cleanly.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a straightforward whitelist update with one open question about intentionally omitted cudnn suppressions.

The whitelist update is mechanical and low-risk. The only open question is whether the two cudnn module suppressions present in 14.0.1 were deliberately dropped for 14.1.0, or accidentally omitted. If they were accidentally omitted and cupy 14.1.0 still fails to load those modules, the checker would start rejecting valid environments. Everything else in the change looks correct and consistent with prior entries.

checker/whitelists/python-3.12.10/linux-x64.json — specifically the cupy 14.1.0 block and its missing cudnn entries.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/tidy-sheep-see.md | Adds a patch-level changeset entry for the cupy/PFrames whitelist update. |
| checker/whitelists/python-3.12.10/linux-x64.json | Removes whitelist entries for cupy 13.6.0 and 14.0.1, adds entry for 14.1.0 (missing cudnn entries vs predecessors), and adds new entries for librmm_cu12 25.6.0, libcudf_cu12 25.6.0, and torch 2.9.1+cpu. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PFrames bump] --> B[cupy bumped to 14.1.0]
    A --> C[librmm_cu12 25.6.0 added]
    A --> D[libcudf_cu12 25.6.0 added]
    A --> E[torch 2.9.1+cpu added]
    B --> F[Remove cupy 13.6.0 whitelist entry]
    B --> G[Remove cupy 14.0.1 whitelist entry]
    B --> H[Add cupy 14.1.0 whitelist entry]
    H --> I{cudnn suppressions?}
    I -->|Present in 14.0.1| J[cupy_backends.cuda.libs.cudnn\ncupyx.cudnn]
    I -->|Missing in 14.1.0| K[Omitted — intentional?]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `checker/whitelists/python-3.12.10/linux-x64.json`, line 5-16 ([link](https://github.com/platforma-open/runenv-python-3/blob/dcb189e572436f79c8b0c2fd361d72c5c106610a/checker/whitelists/python-3.12.10/linux-x64.json#L5-L16)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **cudnn entries absent from 14.1.0 whitelist**

   The 14.0.1 (and 13.6.0) entries included two cudnn-related suppressions — `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` — that are not present in the new 14.1.0 block. If cupy 14.1.0 genuinely resolved those missing-library errors (i.e. the modules now load cleanly without libcudnn.so.8 on the path) then the omission is correct. But if the errors still occur at runtime, the checker will flag them as unexpected failures on any environment running 14.1.0. Could you confirm whether these two modules were intentionally removed?

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: checker/whitelists/python-3.12.10/linux-x64.json
   Line: 5-16

   Comment:
   **cudnn entries absent from 14.1.0 whitelist**

   The 14.0.1 (and 13.6.0) entries included two cudnn-related suppressions — `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` — that are not present in the new 14.1.0 block. If cupy 14.1.0 genuinely resolved those missing-library errors (i.e. the modules now load cleanly without libcudnn.so.8 on the path) then the omission is correct. But if the errors still occur at runtime, the checker will flag them as unexpected failures on any environment running 14.1.0. Could you confirm whether these two modules were intentionally removed?

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
checker/whitelists/python-3.12.10/linux-x64.json:5-16
**cudnn entries absent from 14.1.0 whitelist**

The 14.0.1 (and 13.6.0) entries included two cudnn-related suppressions — `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` — that are not present in the new 14.1.0 block. If cupy 14.1.0 genuinely resolved those missing-library errors (i.e. the modules now load cleanly without libcudnn.so.8 on the path) then the omission is correct. But if the errors still occur at runtime, the checker will flag them as unexpected failures on any environment running 14.1.0. Could you confirm whether these two modules were intentionally removed?


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix checker after PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/dcb189e572436f79c8b0c2fd361d72c5c106610a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33870672)</sub>

<!-- /greptile_comment -->