### PR TITLE
PFrames bump fix

### DIFF
--- a/.changeset/giant-monkeys-roll.md
+++ b/.changeset/giant-monkeys-roll.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3': patch
+---
+
+PFrames bump fix

--- a/checker/whitelists/python-3.12.10-rapids/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-rapids/linux-x64.json
@@ -9,21 +9,7 @@
     "cucim.clara.cucim.kit.cumed@25.04.00": "invalid syntax",
     "cucim.clara.cucim.kit.cuslide@25.04.00": "invalid syntax"
   },
-  "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl": {
-    "cupy.cuda.cufft": "libcufft.so.11: cannot open shared object file: No such file or directory",
-    "cupy.cuda.jitify": "libnvrtc.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cublas": "libcublas.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cudnn": "libcudnn.so.8: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.curand": "libcurand.so.10: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cusolver": "libcusolver.so.11: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cusparse": "libcusparse.so.12: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.cutensor": "libcutensor.so.2: cannot open shared object file: No such file or directory",
-    "cupy_backends.cuda.libs.nccl": "libnccl.so.2: cannot open shared object file: No such file or directory",
-    "cupyx.cudnn": "libcudnn.so.8: cannot open shared object file: No such file or directory",
-    "cupyx.cusolver": "libcusolver.so.11: cannot open shared object file: No such file or directory",
-    "cupyx.cutensor": "libcutensor.so.2: cannot open shared object file: No such file or directory"
-  },
-  "cupy_cuda12x-14.0.1-cp312-cp312-manylinux2014_x86_64.whl": {
+  "cupy_cuda12x-*.whl": {
     "cupy.cuda.cufft": "libcufft.so.11: cannot open shared object file: No such file or directory",
     "cupy.cuda.jitify": "libnvrtc.so.12: cannot open shared object file: No such file or directory",
     "cupy_backends.cuda.libs.cublas": "libcublas.so.12: cannot open shared object file: No such file or directory",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consolidates two version-pinned whitelist entries for `cupy_cuda12x` (versions 13.6.0 and 14.0.1) into a single wildcard pattern `cupy_cuda12x-*.whl`, matching the convention already used for `charset_normalizer`, `numba`, and `scipy` in the same file.

- The wildcard entry matches the module set from 14.0.1; two `cudnn`-related modules (`cupy_backends.cuda.libs.cudnn`, `cupyx.cudnn`) that were whitelisted only in 13.6.0 are dropped — this appears intentional since 14.0.1 had already removed them.
- A patch-level changeset entry is added to trigger a release.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the wildcard consolidation is consistent with patterns already used in the file and the dropped cudnn entries reflect the 14.0.1 baseline.

The change is straightforward and follows existing conventions. The only notable detail is that two cudnn-related whitelist entries present in the old 13.6.0 block are absent from the new wildcard, which is fine as long as the bump targets 14.0.1+.

checker/whitelists/python-3.12.10-rapids/linux-x64.json — confirm the cudnn module omission is intentional for the target cupy version.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/giant-monkeys-roll.md | New patch-level changeset entry for the PFrames bump fix |
| checker/whitelists/python-3.12.10-rapids/linux-x64.json | Consolidates two version-pinned cupy_cuda12x whitelist entries (13.6.0 and 14.0.1) into a single wildcard pattern; drops cudnn-related entries that were only present in 13.6.0 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `checker/whitelists/python-3.12.10-rapids/linux-x64.json`, line 12-23 ([link](https://github.com/platforma-open/runenv-python-3/blob/f2d775be276c2ec65db4e7f3cc80d4776635a1ad/checker/whitelists/python-3.12.10-rapids/linux-x64.json#L12-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **cudnn entries silently dropped in wildcard consolidation**

   The 13.6.0 entry whitelisted `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` (both failing with `libcudnn.so.8: cannot open shared object file`), but the new wildcard `cupy_cuda12x-*.whl` omits them. If the bumped version or a future version re-introduces `cudnn` as a hard import, the checker will report a new unexpected failure not covered by the whitelist. This is low-risk if the bump targets 14.0.1+ (which already lacked those entries), but worth confirming the dropped entries are intentional.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: checker/whitelists/python-3.12.10-rapids/linux-x64.json
   Line: 12-23

   Comment:
   **cudnn entries silently dropped in wildcard consolidation**

   The 13.6.0 entry whitelisted `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` (both failing with `libcudnn.so.8: cannot open shared object file`), but the new wildcard `cupy_cuda12x-*.whl` omits them. If the bumped version or a future version re-introduces `cudnn` as a hard import, the checker will report a new unexpected failure not covered by the whitelist. This is low-risk if the bump targets 14.0.1+ (which already lacked those entries), but worth confirming the dropped entries are intentional.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
checker/whitelists/python-3.12.10-rapids/linux-x64.json:12-23
**cudnn entries silently dropped in wildcard consolidation**

The 13.6.0 entry whitelisted `cupy_backends.cuda.libs.cudnn` and `cupyx.cudnn` (both failing with `libcudnn.so.8: cannot open shared object file`), but the new wildcard `cupy_cuda12x-*.whl` omits them. If the bumped version or a future version re-introduces `cudnn` as a hard import, the checker will report a new unexpected failure not covered by the whitelist. This is low-risk if the bump targets 14.0.1+ (which already lacked those entries), but worth confirming the dropped entries are intentional.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump fix"](https://github.com/platforma-open/runenv-python-3/commit/f2d775be276c2ec65db4e7f3cc80d4776635a1ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33901610)</sub>

<!-- /greptile_comment -->