### PR TITLE
feat: add support for new Python 3.12.10-humanness builds in CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,7 +94,13 @@ jobs:
           {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"},
           {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-scientific-slim"},
           {"os":"macos-14-large", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"},
-          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"}
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-scientific-slim"},
+
+          {"os":"ubuntu-large-arm64", "arch":"arm64", "selector":"./python-3.12.10-humanness"},
+          {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-humanness"},
+          {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-humanness"},
+          {"os":"macos-14-large", "arch":"amd64", "selector":"./python-3.12.10-humanness"},
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-humanness"}
         ]
 
       sign-binaries: |


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the `python-3.12.10-humanness` build variant to the CI matrix, which packages `polars-lts-cpu` and `promb` for humanness scoring workloads.

- Five new matrix entries are added (arm64/amd64 Linux, arm64/amd64 macOS, amd64 Windows), consistent with the full-platform pattern used by `scientific-slim`, `h5ad`, `sccoda`, and `parapred`.
- The `python-3.12.10-humanness` directory already exists with a matching `package.json` declaring all five platform roots, so the workflow entries align correctly with the package definition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a straightforward matrix expansion with no logic modifications; the referenced package directory exists and targets the same five platforms.

The diff is a mechanical addition of five JSON objects following the established pattern. The python-3.12.10-humanness package is already present in the repo with a package.json that declares all five platform roots, so nothing is missing or mismatched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Adds 5 CI matrix entries for the new python-3.12.10-humanness build across all supported platforms (arm64/amd64 Linux, arm64/amd64 macOS, amd64 Windows), matching the pattern used by other full-platform variants. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / pull_request to main] --> B[init job]
    B --> C[run job - node-matrix-pnpm]
    C --> D{pre-calculated-task-list}
    D --> E[python-3.12.10 × 5 platforms]
    D --> F[python-3.12.10-empty × 5 platforms]
    D --> G[python-3.12.10-atls × 2 platforms]
    D --> H[python-3.12.10-h5ad × 5 platforms]
    D --> I[python-3.12.10-rapids × 5 platforms]
    D --> J[python-3.12.10-sccoda × 5 platforms]
    D --> K[python-3.12.10-parapred × 5 platforms]
    D --> L[python-3.12.10-scientific-slim × 5 platforms]
    D --> M[python-3.12.10-humanness × 5 platforms - NEW]
    M --> N1[ubuntu-large-arm64 arm64]
    M --> N2[ubuntu-large-amd64 amd64]
    M --> N3[macos-14 arm64]
    M --> N4[macos-14-large amd64]
    M --> N5[windows-latest amd64]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add support for new Python 3.12.10..."](https://github.com/platforma-open/runenv-python-3/commit/560ffab8f0e92833cefcbcb6cbcd54ea43296520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34176569)</sub>

<!-- /greptile_comment -->