### PR TITLE
python-3.12.10-atls model files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ test-dry-run.json
 *.tar.gz
 *.tgz
 *.zip
+
+# ImmuneBuilder model weights are downloaded by python-3.12.10-atls/scripts/
+# download-immunebuilder-weights.mjs at build time; ~700 MB, not for git.
+python-3.12.10-atls/shared/immunebuilder-weights/

--- a/python-3.12.10-atls/config.json
+++ b/python-3.12.10-atls/config.json
@@ -76,6 +76,10 @@
           {
             "from": "linux-x64/site-packages/",
             "to": "{site-packages}/"
+          },
+          {
+            "from": "shared/immunebuilder-weights/",
+            "to": "share/immunebuilder-weights/"
           }
         ]
       },
@@ -92,6 +96,10 @@
           {
             "from": "macosx-aarch64/site-packages/",
             "to": "{site-packages}/"
+          },
+          {
+            "from": "shared/immunebuilder-weights/",
+            "to": "share/immunebuilder-weights/"
           }
         ]
       }

--- a/python-3.12.10-atls/package.json
+++ b/python-3.12.10-atls/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "cleanup": "rm -rf ./pkg-*.tgz ./pydist ./dist/ ./build/",
     "reset": "pnpm run cleanup && rm -rf ./node_modules ./.turbo",
-    "build": "pl-py-builder",
+    "fetch-weights": "node scripts/download-immunebuilder-weights.mjs",
+    "build": "pnpm run fetch-weights && pl-py-builder",
     "after-prebuild": "pl-pkg publish packages",
     "before-publish": "pl-pkg prepublish"
   },

--- a/python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs
+++ b/python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs
@@ -1,0 +1,67 @@
+// Pre-fetch ImmuneBuilder model weights into shared/immunebuilder-weights/
+// so the runenv build can stage them via copyFiles into share/immunebuilder-weights/
+// of the published environment. Avoids the unstable on-first-use download from
+// Zenodo when the 3d-structure-prediction block runs against a package-deployed
+// runtime.
+//
+// Idempotent: re-runs skip files whose on-disk size already matches the
+// expected Zenodo blob size. Partial downloads land in a .part sidecar and
+// are atomically renamed on success.
+
+import { createWriteStream, existsSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pipeline } from 'node:stream/promises';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const targetDir = resolve(__dirname, '..', 'shared', 'immunebuilder-weights');
+
+// Sizes are the byte length of the Zenodo blobs (record 7258553). They double
+// as an integrity check + early-fail signal for truncated downloads; ImmuneBuilder
+// itself only checks that the file is non-empty and doesn't start with "EMPTY",
+// which is too loose to catch partial downloads.
+const FILES = [
+  { name: 'antibody_model_1', size: 61050011 },
+  { name: 'antibody_model_2', size: 214267291 },
+  { name: 'antibody_model_3', size: 214267291 },
+  { name: 'antibody_model_4', size: 214267291 },
+  { name: 'nanobody_model_1', size: 61050011 },
+  { name: 'nanobody_model_2', size: 214267291 },
+  { name: 'nanobody_model_3', size: 214267291 },
+  { name: 'nanobody_model_4', size: 214267291 },
+];
+
+const BASE = 'https://zenodo.org/record/7258553/files';
+
+async function downloadOne({ name, size }) {
+  const dest = join(targetDir, name);
+  if (existsSync(dest) && statSync(dest).size === size) {
+    console.log(`  ✓ ${name} (cached)`);
+    return;
+  }
+  const url = `${BASE}/${name}?download=1`;
+  console.log(`  ↓ ${name} from ${url}`);
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  const tmp = `${dest}.part`;
+  try {
+    await pipeline(res.body, createWriteStream(tmp));
+    const got = statSync(tmp).size;
+    if (got !== size) {
+      throw new Error(`${name}: expected ${size} bytes, got ${got}`);
+    }
+    await rename(tmp, dest);
+    console.log(`  ✓ ${name} (${got} bytes)`);
+  } catch (err) {
+    if (existsSync(tmp)) unlinkSync(tmp);
+    throw err;
+  }
+}
+
+mkdirSync(targetDir, { recursive: true });
+console.log(`Fetching ImmuneBuilder weights into ${targetDir}`);
+for (const f of FILES) {
+  await downloadOne(f);
+}
+console.log('ImmuneBuilder weights ready');

--- a/python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs
+++ b/python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs
@@ -8,8 +8,8 @@
 // expected Zenodo blob size. Partial downloads land in a .part sidecar and
 // are atomically renamed on success.
 
-import { createWriteStream, existsSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { mkdir, rename, stat, unlink } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pipeline } from 'node:stream/promises';
@@ -34,32 +34,52 @@ const FILES = [
 
 const BASE = 'https://zenodo.org/record/7258553/files';
 
+// Zenodo can stall mid-transfer. One AbortController covers both the fetch
+// (headers) and the pipeline (streamed body) — clearing the timer right after
+// fetch() resolves would still leave a mid-body stall hanging indefinitely.
+const DOWNLOAD_TIMEOUT_MS = 15 * 60 * 1000;
+
+async function statOrNull(path) {
+  try {
+    return await stat(path);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
 async function downloadOne({ name, size }) {
   const dest = join(targetDir, name);
-  if (existsSync(dest) && statSync(dest).size === size) {
+  const existing = await statOrNull(dest);
+  if (existing && existing.size === size) {
     console.log(`  ✓ ${name} (cached)`);
     return;
   }
   const url = `${BASE}/${name}?download=1`;
   console.log(`  ↓ ${name} from ${url}`);
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
   const tmp = `${dest}.part`;
   try {
+    const res = await fetch(url, { redirect: 'follow', signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     await pipeline(res.body, createWriteStream(tmp));
-    const got = statSync(tmp).size;
+    const got = (await stat(tmp)).size;
     if (got !== size) {
       throw new Error(`${name}: expected ${size} bytes, got ${got}`);
     }
     await rename(tmp, dest);
     console.log(`  ✓ ${name} (${got} bytes)`);
   } catch (err) {
-    if (existsSync(tmp)) unlinkSync(tmp);
+    // Best-effort cleanup; ENOENT is fine if the .part was never created.
+    await unlink(tmp).catch(() => {});
     throw err;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-mkdirSync(targetDir, { recursive: true });
+await mkdir(targetDir, { recursive: true });
 console.log(`Fetching ImmuneBuilder weights into ${targetDir}`);
 for (const f of FILES) {
   await downloadOne(f);


### PR DESCRIPTION
Download and pack model weights during python-3.12.10-atls env build

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a Node.js script that pre-fetches ~1.3 GB of ImmuneBuilder model weights from Zenodo at build time, staging them into `shared/immunebuilder-weights/` so they can be bundled into the `python-3.12.10-atls` runenv instead of being downloaded on first use at runtime.

- **Download script** (`download-immunebuilder-weights.mjs`): Idempotent via size-based cache check, uses atomic `.part` \u2192 final rename, and cleans up partial files on error. Two suggestions: add a per-request `AbortController` timeout to prevent indefinite hangs on stalled Zenodo connections, and switch to `Promise.all` for concurrent downloads.
- **`config.json`**: Correctly wires `shared/immunebuilder-weights/` \u2192 `share/immunebuilder-weights/` for `linux-x64` and `macosx-aarch64`.
- **`package.json` / `.gitignore`**: Build script updated to run `fetch-weights` before `pl-py-builder`; weight directory correctly excluded from git.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the download script is well-structured with atomic writes and cleanup on failure, and the config/package changes are correct.

The download script handles the happy path correctly and all config changes are straightforward. The missing per-request timeout means a stalled Zenodo connection can block the build indefinitely, and sequential downloads of ~1.3 GB inflate CI time unnecessarily. Neither blocks correctness, but both are worth addressing before this runs routinely in CI.

python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs — timeout handling and download concurrency
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs | New script to pre-fetch ~1.3 GB of ImmuneBuilder model weights from Zenodo; idempotent with size-based cache check and atomic rename. Missing a per-request timeout and uses sequential downloads. |
| python-3.12.10-atls/config.json | Adds copyFiles entry mapping shared/immunebuilder-weights/ to share/immunebuilder-weights/ for linux-x64 and macosx-aarch64; correctly omits unsupported platforms. |
| python-3.12.10-atls/package.json | Adds fetch-weights script and prepends it to build via &&. |
| .gitignore | Correctly excludes the shared/immunebuilder-weights/ directory from version control. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Build as pnpm build
    participant Script as download-immunebuilder-weights.mjs
    participant FS as shared/immunebuilder-weights/
    participant Zenodo as zenodo.org/record/7258553
    participant Builder as pl-py-builder

    Build->>Script: pnpm run fetch-weights
    loop For each of 8 model files
        Script->>FS: existsSync + statSync (size check)
        alt cached (size matches)
            Script-->>Script: skip
        else missing or wrong size
            Script->>Zenodo: fetch(url, redirect:follow)
            Zenodo-->>Script: response body stream
            Script->>FS: pipeline to file.part
            Script->>Script: verify size
            Script->>FS: rename .part to final
        end
    end
    Script-->>Build: exit 0
    Build->>Builder: pl-py-builder
    Builder->>FS: copyFiles shared to share (linux-x64, macosx-aarch64)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs:43-46
No fetch/stream timeout is set. Each model file is up to ~214 MB, and Zenodo is a public academic mirror that can stall mid-transfer. Without an `AbortController` timeout, a stalled connection will block the build indefinitely — the process will never proceed past `pipeline(res.body, ...)` even if the remote end has gone silent.

```suggestion
  const url = `${BASE}/${name}?download=1`;
  console.log(`  ↓ ${name} from ${url}`);
  const controller = new AbortController();
  const timer = setTimeout(() => controller.abort(), 15 * 60 * 1000);
  let res;
  try {
    res = await fetch(url, { redirect: 'follow', signal: controller.signal });
  } finally {
    clearTimeout(timer);
  }
  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
```

### Issue 2 of 2
python-3.12.10-atls/scripts/download-immunebuilder-weights.mjs:62-67
Downloads are sequential — each file waits for the previous one to complete. The 8 files total roughly 1.3 GB from a single Zenodo record; downloading them concurrently would cut wall-clock build time substantially.

```suggestion
mkdirSync(targetDir, { recursive: true });
console.log(`Fetching ImmuneBuilder weights into ${targetDir}`);
await Promise.all(FILES.map(f => downloadOne(f)));
console.log('ImmuneBuilder weights ready');
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Download and pack model weights during p..."](https://github.com/platforma-open/runenv-python-3/commit/39194fe1cd4671d23ff24c9dbf2bf10607106b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34178687)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->