### PR TITLE
feat: add whitelists for scipy import errors in Python 3.12.10-humanness builds

### DIFF
--- a/checker/whitelists/python-3.12.10-humanness/linux-aarch64.json
+++ b/checker/whitelists/python-3.12.10-humanness/linux-aarch64.json
@@ -1,1 +1,5 @@
-{}
+{
+  "scipy-1.*.whl": {
+    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module"
+  }
+}

--- a/checker/whitelists/python-3.12.10-humanness/linux-x64.json
+++ b/checker/whitelists/python-3.12.10-humanness/linux-x64.json
@@ -1,1 +1,5 @@
-{}
+{
+  "scipy-1.*.whl": {
+    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module"
+  }
+}

--- a/checker/whitelists/python-3.12.10-humanness/macosx-aarch64.json
+++ b/checker/whitelists/python-3.12.10-humanness/macosx-aarch64.json
@@ -1,10 +1,5 @@
 {
-  "scipy-1.*-macosx_12_0_arm64.whl": {
-    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
-    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'. Did you mean: 'SeedSequence"
-  },
-  "scipy-1.*-macosx_14_0_arm64.whl": {
-    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
-    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'. Did you mean: 'SeedSequence"
+  "scipy-1.*.whl": {
+    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module"
   }
 }

--- a/checker/whitelists/python-3.12.10-humanness/macosx-x64.json
+++ b/checker/whitelists/python-3.12.10-humanness/macosx-x64.json
@@ -1,10 +1,5 @@
 {
-  "scipy-1.*-macosx_12_0_x86_64.whl": {
-    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
-    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'. Did you mean: 'SeedSequence"
-  },
-  "scipy-1.*-macosx_14_0_x86_64.whl": {
-    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
-    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'. Did you mean: 'SeedSequence"
+  "scipy-1.*.whl": {
+    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module"
   }
 }

--- a/checker/whitelists/python-3.12.10-humanness/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-humanness/windows-x64.json
@@ -1,1 +1,5 @@
-{}
+{
+  "scipy-1.*.whl": {
+    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module"
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds scipy import error whitelists for the `python-3.12.10-humanness` build on `linux-aarch64` and `linux-x64`, whitelisting the known `scipy.linalg._matfuncs_sqrtm_triu` circular-import failure.

- Both new Linux files whitelist `scipy.linalg._matfuncs_sqrtm_triu` under `scipy-1.*.whl`, consistent with other builds.
- Every other Linux build that includes scipy (e.g. `sccoda`, `h5ad`) also whitelists `scipy.stats._unuran.unuran_wrapper` for the `'SeedlessSequence'` numpy compatibility error — and the `macosx-aarch64.json` for this same humanness build includes both entries. It's worth confirming whether the Linux humanness build uses a newer numpy that avoids this error, or whether the second entry is missing.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge if the humanness Linux build intentionally uses a numpy version that avoids the unuran_wrapper error; otherwise the checker may silently miss a known failure.

The changes are minimal whitelist JSON additions. The only concern is that `scipy.stats._unuran.unuran_wrapper` is whitelisted in every other Linux scipy entry in the repo (and in the macOS counterpart for this very build), but is absent from the two new Linux files. If the humanness build's numpy version on Linux does exhibit this error, it would be treated as unexpected by the checker.

Both `linux-aarch64.json` and `linux-x64.json` — confirm whether the `unuran_wrapper` entry should be present, consistent with all other Linux scipy whitelists.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| checker/whitelists/python-3.12.10-humanness/linux-aarch64.json | Adds scipy whitelist entry for linux-aarch64, but only includes one of the two scipy import errors seen in every other Linux scipy whitelist in the repo. |
| checker/whitelists/python-3.12.10-humanness/linux-x64.json | Adds scipy whitelist entry for linux-x64, but only includes one of the two scipy import errors seen in every other Linux scipy whitelist in the repo. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scipy-1.*.whl import check] --> B{Platform}
    B --> |linux-x64 / linux-aarch64| C[Whitelist lookup]
    B --> |macosx-aarch64| D[Whitelist lookup]
    C --> E[scipy.linalg._matfuncs_sqrtm_triu ✅ whitelisted]
    C --> F[scipy.stats._unuran.unuran_wrapper ❓ NOT whitelisted]
    D --> G[scipy.linalg._matfuncs_sqrtm_triu ✅ whitelisted]
    D --> H[scipy.stats._unuran.unuran_wrapper ✅ whitelisted]
    F --> I{Does error occur on Linux?}
    I -->|Yes - numpy older| J[Checker flags as unexpected failure]
    I -->|No - newer numpy| K[No issue]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
checker/whitelists/python-3.12.10-humanness/linux-x64.json:1-5
Every other Linux build in this repo that whitelists scipy includes a second entry for `scipy.stats._unuran.unuran_wrapper` alongside `scipy.linalg._matfuncs_sqrtm_triu` (see `sccoda/linux-x64.json`, `h5ad/linux-x64.json`, `sccoda/linux-aarch64.json`). The `macosx-aarch64.json` for this same humanness build also includes both. If the humanness Linux build uses the same numpy version that triggers the `'SeedlessSequence'` error, this entry is missing and the checker will treat it as an unexpected failure.

```suggestion
{
  "scipy-1.*.whl": {
    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
  }
}
```

### Issue 2 of 2
checker/whitelists/python-3.12.10-humanness/linux-aarch64.json:1-5
Same pattern as `linux-x64.json` — every other Linux scipy whitelist in the repo (`sccoda/linux-aarch64.json`, `h5ad/linux-aarch64.json`) includes the `scipy.stats._unuran.unuran_wrapper` entry. If this error also occurs on Linux aarch64 for the humanness build, omitting it here would cause the checker to flag it as unexpected.

```suggestion
{
  "scipy-1.*.whl": {
    "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
    "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add whitelists for scipy import er..."](https://github.com/platforma-open/runenv-python-3/commit/196af072af483d47f1e2086f6c4054efd007a6eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34188411)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->