### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/late-pugs-flow.md
+++ b/.changeset/late-pugs-flow.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.37",
+      "polars-pf==1.1.40",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `polars-pf` dependency from `1.1.37` to `1.1.40` in the Python 3.12.10 environment config and includes the corresponding changeset entry for a patch release.

- `python-3.12.10/config.json`: `polars-pf` pinned version updated from `1.1.37` → `1.1.40`; all other pinned dependencies remain unchanged.
- `.changeset/late-pugs-flow.md`: new changeset added to trigger a patch-level version bump for `@platforma-open/milaboratories.runenv-python-3.12.10`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a single-dependency version bump with an accompanying changeset; no logic, API contracts, or other dependencies are affected.

The change is minimal — one version string updated for polars-pf and a matching changeset file. There are no structural changes, no logic modifications, and the changeset correctly marks it as a patch release.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Bumps polars-pf from 1.1.37 to 1.1.40; no other dependency changes. |
| .changeset/late-pugs-flow.md | New changeset marking the polars-pf bump as a patch release for the python-3.12.10 package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: PFrames bump] --> B[python-3.12.10/config.json]
    A --> C[.changeset/late-pugs-flow.md]
    B --> D["polars-pf: 1.1.37 → 1.1.40"]
    C --> E["patch release: @platforma-open/milaboratories.runenv-python-3.12.10"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/489a5bc70f170d6b7964ae905b32bceba2118ae1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35108697)</sub>

<!-- /greptile_comment -->