### PR TITLE
Fix merge related issue

### DIFF
--- a/.changeset/cyan-toes-create.md
+++ b/.changeset/cyan-toes-create.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-clustering': patch
+'@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': patch
+'@platforma-open/milaboratories.runenv-python-3': patch
+'runenv-python-builder': patch
+---
+
+Fix incorrect merge with main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,7 +106,7 @@ jobs:
           {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-clustering"},
           {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-clustering"},
           {"os":"macos-14-large", "arch":"amd64", "selector":"./python-3.12.10-clustering"},
-          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-clustering"}
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-clustering"},
 
           {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-torch-cuda"},
           {"os":"macos-14", "arch":"arm64", "selector":"./python-3.12.10-torch-cuda"}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing trailing comma in the GitHub Actions build matrix that was introduced during a merge conflict. The broken JSON caused the `python-3.12.10-torch-cuda` entries to be dropped from the CI matrix.

- **`build.yaml`**: Adds a trailing comma after the last `./python-3.12.10-clustering` matrix entry so the subsequent `./python-3.12.10-torch-cuda` entries are included in the build matrix.
- **`.changeset/cyan-toes-create.md`**: Adds a patch-level changeset entry for the four affected packages.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-character comma addition that restores a previously broken CI matrix.

The fix is minimal and targeted: a missing comma that caused the torch-cuda build targets to be silently omitted from the CI matrix is now corrected. No logic, scripts, or runtime behavior is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Adds missing trailing comma after the windows-latest clustering entry, restoring the torch-cuda matrix rows that were silently dropped. |
| .changeset/cyan-toes-create.md | New changeset file recording a patch release for the four affected packages. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build Matrix JSON Array] --> B[scientific-slim entries]
    A --> C[humanness entries]
    A --> D[clustering entries]
    A --> E[torch-cuda entries]

    D -->|Before fix: missing comma| F[❌ JSON parse error\ntorch-cuda entries dropped]
    D -->|After fix: trailing comma added| E
    E --> G[✅ Full matrix executed\nAll environments built]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/runenv-python-3/commit/4e51c7205f6a1e486399dd6838a841bda587f3da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35117468)</sub>

<!-- /greptile_comment -->