### PR TITLE
MILAB-6354: Add atriegc==0.0.4

### DIFF
--- a/.changeset/atriegc-add.md
+++ b/.changeset/atriegc-add.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Add atriegc==0.0.4 for the clonotype-convergence block. linux-aarch64 has no upstream wheel; built from source there (same pattern as parasail).

--- a/.changeset/clonotype-convergence-deps.md
+++ b/.changeset/clonotype-convergence-deps.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Add Levenshtein==0.27.3 + rapidfuzz==3.14.5 for the clonotype-convergence block's cluster filter (vendored `output_HC.py` uses `from Levenshtein import distance`).

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -37,8 +37,14 @@
       "Cython==3.1.4",
       "fa2_modified==0.4",
       "biopython==1.87",
-      "tmtools==0.3.0"
+      "tmtools==0.3.0",
+      "atriegc==0.0.4"
     ],
-    "overrides": {}
+    "overrides": {},
+    "forceSource": {
+      "atriegc": {
+        "linux-aarch64": "No atriegc wheel for Linux ARM64 on PyPI; build from source"
+      }
+    }
   }
 }

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -38,7 +38,9 @@
       "fa2_modified==0.4",
       "biopython==1.87",
       "tmtools==0.3.0",
-      "atriegc==0.0.4"
+      "atriegc==0.0.4",
+      "Levenshtein==0.27.3",
+      "rapidfuzz==3.14.5"
     ],
     "overrides": {},
     "forceSource": {


### PR DESCRIPTION
For the clonotype-convergence block (Hamming-1 trie used by the fast-STAR statistic). PyPI ships cp312 wheels for linux-x64, macosx x64/aarch64, windows-x64. linux-aarch64 has no upstream wheel — built from source there, mirroring the parasail pattern in shared-config.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `atriegc==0.0.4` (a Hamming-1 trie library used by the clonotype-convergence block's fast-STAR statistic) to the Python 3.12.10 environment's dependency list, with a `forceSource` override for `linux-aarch64` where no upstream wheel is published.

- `atriegc==0.0.4` is appended to `python-3.12.10/config.json` `dependencies`, and a `forceSource` entry is added scoped to `linux-aarch64` only — correctly not including `macosx-aarch64` since the PR description notes PyPI does ship ARM macOS wheels.
- The pattern mirrors the existing `parasail` entry in `shared-config.json` (source-only on platforms without binary wheels), and the changeset file documents the patch release bump with the correct package name.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single new package dependency with a well-scoped platform override that follows an existing working pattern.

The change is minimal: one new package pinned to an exact version, and a forceSource override for the one platform lacking a binary wheel. The override correctly mirrors how parasail is handled in shared-config.json, and the PR description accurately identifies which platforms do and don't ship wheels. No existing dependencies are modified and no shared configuration is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Adds atriegc==0.0.4 to dependencies and a forceSource override for linux-aarch64; follows the established parasail pattern correctly |
| .changeset/atriegc-add.md | Changeset file correctly records a patch bump for the python-3.12.10 package with an accurate description |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[config.json dependencies] -->|includes| B[atriegc==0.0.4]
    B --> C{Platform?}
    C -->|linux-x64| D[Install binary wheel from PyPI]
    C -->|macosx-x64| D
    C -->|macosx-aarch64| D
    C -->|windows-x64| D
    C -->|linux-aarch64| E[forceSource override]
    E --> F[Build from source]
    G[shared-config.json forceSource] -->|same pattern| H[parasail: linux-aarch64 + macosx-aarch64]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6354: Add atriegc==0.0.4"](https://github.com/platforma-open/runenv-python-3/commit/879ef08de9a44c6a105b85ef3d7d713f23509fca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35121189)</sub>

<!-- /greptile_comment -->