### PR TITLE
MILAB-6205: add freesasa 2.2.1 to python-3.12.10 runenv

### DIFF
--- a/.changeset/milab-6205-freesasa.md
+++ b/.changeset/milab-6205-freesasa.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': minor
+---
+
+Add freesasa 2.2.1 to the base Python 3.12.10 run environment. freesasa publishes no cp312 or Linux wheels, so it is declared as a dependency plus a buildWheel entry that compiles the C extension on the native runner for all five platforms. The sdist ships pre-generated C, so the build needs only setuptools and wheel.

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -37,8 +37,33 @@
       "Cython==3.1.4",
       "fa2_modified==0.4",
       "biopython==1.87",
-      "tmtools==0.3.0"
+      "tmtools==0.3.0",
+      "freesasa==2.2.1"
     ],
-    "overrides": {}
+    "overrides": {},
+    "buildWheel": {
+      "freesasa": {
+        "linux-x64": {
+          "reason": "freesasa publishes no cp312 / Linux wheel; compile the C extension on the runner (sdist ships pre-generated freesasa.c, plain C build)",
+          "buildRequires": ["setuptools", "wheel"]
+        },
+        "linux-aarch64": {
+          "reason": "No cp312 / Linux ARM64 wheel; compile on the native ARM runner",
+          "buildRequires": ["setuptools", "wheel"]
+        },
+        "macosx-x64": {
+          "reason": "No cp312 wheel; compile on the runner",
+          "buildRequires": ["setuptools", "wheel"]
+        },
+        "macosx-aarch64": {
+          "reason": "No cp312 / arm64 wheel; compile on the runner",
+          "buildRequires": ["setuptools", "wheel"]
+        },
+        "windows-x64": {
+          "reason": "No cp312 wheel; compile with MSVC on the runner (dev headers/libs supplied by the Windows builder)",
+          "buildRequires": ["setuptools", "wheel"]
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

Adds `freesasa==2.2.1` to the base `python-3.12.10` run environment.

freesasa publishes no cp312 wheel and no Linux wheel of any kind (only macOS-x86 and Windows wheels for older Python). A plain dependency would therefore be silently skipped on every platform (wheel download fails, source not allowed by the default resolution policy, `strictMissing: false`), shipping the runenv without freesasa.

So it is declared as a dependency **and** given a `buildWheel` entry for all five platforms, compiling the C extension on the native runner. The sdist ships the pre-generated `freesasa.c`, so the build needs only `setuptools` + `wheel` (no cmake / clang-cl handling like kalign).

## Why

Required so the 3D Structure-Based Liabilities block (MILAB-6205) can run on the Python run environment instead of a Docker-only software image.

## Validation

- Source build + native import verified locally on linux-x64 (`pip wheel freesasa==2.2.1 --no-binary freesasa` with gcc + setuptools, then `import freesasa`).
- macOS-arm64 and Windows-cp312 (no published-wheel precedent) will be exercised by the runenv CI import checker on the first run.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `freesasa==2.2.1` to the `python-3.12.10` base runenv. Because freesasa publishes no cp312 or Linux wheels on PyPI, the package is paired with a `buildWheel` block that compiles the C extension from the sdist on all five supported platforms using only `setuptools` and `wheel`.

- `python-3.12.10/config.json` — appends `freesasa==2.2.1` to `dependencies` and adds per-platform `buildWheel` entries (linux-x64, linux-aarch64, macosx-x64, macosx-aarch64, windows-x64), each citing the reason and minimal build requirements.
- `.changeset/milab-6205-freesasa.md` — declares the corresponding minor-version changeset for the package.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a straightforward config addition; the only notable issue is a missing trailing newline introduced by the edit.

Both files contain only config/metadata changes with no executable logic. The buildWheel structure matches the established pattern in python-3.12.10-clustering/config.json. The sole issue is that the edit dropped the trailing newline that was present in the original file, diverging from the convention followed by every other config.json in the repo.

python-3.12.10/config.json — missing trailing newline at end of file
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Adds freesasa==2.2.1 to dependencies with buildWheel entries for all five platforms; also drops the trailing newline at end of file |
| .changeset/milab-6205-freesasa.md | New changeset file declaring a minor version bump for the python-3.12.10 runenv; content accurately describes the change |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[config.json: freesasa==2.2.1 in dependencies] --> B{Wheel available on PyPI?}
    B -- "No cp312 / Linux wheel" --> C[buildWheel entry triggered]
    B -- "macOS-x86 / Windows (older Python)" --> C
    C --> D{Platform}
    D --> E[linux-x64\nsetuptools + wheel\ngcc C build]
    D --> F[linux-aarch64\nsetuptools + wheel\nnative ARM build]
    D --> G[macosx-x64\nsetuptools + wheel\nxcode C build]
    D --> H[macosx-aarch64\nsetuptools + wheel\nnative Apple Silicon build]
    D --> I[windows-x64\nsetuptools + wheel\nMSVC C build]
    E & F & G & H & I --> J[Native .whl artifact]
    J --> K[runenv CI import checker validates wheel]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
python-3.12.10/config.json:68-69
The file no longer ends with a trailing newline, whereas the original did. All other `config.json` files in the repo (e.g. `python-3.12.10-clustering/config.json`) end with a newline, so this diverges from the established convention and can cause noisy diffs in tools that expect POSIX text files.

```suggestion
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6205: add freesasa 2.2.1 to python..."](https://github.com/platforma-open/runenv-python-3/commit/e3a8e95432a832796b1ac93085e387f420fb57f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35131489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->