### PR TITLE
Revert MILAB-6205: freesasa 2.2.1 (Windows runenv build failed)

### DIFF
--- a/.changeset/milab-6205-freesasa.md
+++ b/.changeset/milab-6205-freesasa.md
@@ -1,5 +1,0 @@
----
-'@platforma-open/milaboratories.runenv-python-3.12.10': minor
----
-
-Add freesasa 2.2.1 to the base Python 3.12.10 run environment. freesasa publishes no cp312 or Linux wheels, so it is declared as a dependency plus a buildWheel entry that compiles the C extension on the native runner for all five platforms. The sdist ships pre-generated C, so the build needs only setuptools and wheel.

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -37,33 +37,8 @@
       "Cython==3.1.4",
       "fa2_modified==0.4",
       "biopython==1.87",
-      "tmtools==0.3.0",
-      "freesasa==2.2.1"
+      "tmtools==0.3.0"
     ],
-    "overrides": {},
-    "buildWheel": {
-      "freesasa": {
-        "linux-x64": {
-          "reason": "freesasa publishes no cp312 / Linux wheel; compile the C extension on the runner (sdist ships pre-generated freesasa.c, plain C build)",
-          "buildRequires": ["setuptools", "wheel"]
-        },
-        "linux-aarch64": {
-          "reason": "No cp312 / Linux ARM64 wheel; compile on the native ARM runner",
-          "buildRequires": ["setuptools", "wheel"]
-        },
-        "macosx-x64": {
-          "reason": "No cp312 wheel; compile on the runner",
-          "buildRequires": ["setuptools", "wheel"]
-        },
-        "macosx-aarch64": {
-          "reason": "No cp312 / arm64 wheel; compile on the runner",
-          "buildRequires": ["setuptools", "wheel"]
-        },
-        "windows-x64": {
-          "reason": "No cp312 wheel; compile with MSVC on the runner (dev headers/libs supplied by the Windows builder)",
-          "buildRequires": ["setuptools", "wheel"]
-        }
-      }
-    }
+    "overrides": {}
   }
 }


### PR DESCRIPTION
Reverts #86 to restore `main`'s build.

## Why

freesasa's `buildWheel` compiled and passed the native-import check on 4 of 5 platforms (linux-x64, linux-aarch64, macOS-x64, macOS-arm64). The MSVC build on `windows-latest` failed, so the `python-3.12.10` Build NPM package job went red on main.

## Plan to re-land

Re-add freesasa with a Windows-specific `buildWheel` entry (the linux/macOS entries were fine). Likely the same approach kalign uses: build with clang-cl + Ninja and pass `configSettings`, or otherwise adjust the MSVC compile. Will reopen under MILAB-6205 once the Windows build is sorted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reverts #86, removing `freesasa==2.2.1` and its associated `buildWheel` configuration from the Python 3.12.10 run environment after the Windows (`windows-latest`) MSVC build failed, breaking `main`.

- Removes `freesasa==2.2.1` from `python-3.12.10/config.json` dependencies and the entire `buildWheel` block that specified C-extension compilation for all five platforms.
- Deletes the `.changeset/milab-6205-freesasa.md` changeset file, cleanly unwinding the original PR's version bump.
- The revert leaves the file without a trailing newline (minor style nit), but otherwise the rollback is complete and correct.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a clean revert that restores main to its pre-freesasa state; no logic changes, no regressions introduced.

The change removes two additions (a dependency entry and its buildWheel block) and deletes a changeset file — all exactly matching the inverse of #86. The only artifact worth noting is the missing trailing newline in config.json, which has no runtime impact.

No files require special attention; the revert is mechanically straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/milab-6205-freesasa.md | Changeset file for the freesasa addition is deleted as part of the revert — correct and expected. |
| python-3.12.10/config.json | Removes freesasa==2.2.1 from dependencies and the entire buildWheel section; file is left without a trailing newline. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #86: Add freesasa 2.2.1] -->|Windows MSVC build failed| B[main broken]
    B --> C[PR #87: Revert freesasa addition]
    C --> D[Remove freesasa==2.2.1 from dependencies]
    C --> E[Remove buildWheel section for freesasa]
    C --> F[Delete changeset file]
    D & E & F --> G[main restored]
    G --> H[Future: Re-land with Windows-specific buildWheel fix]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
python-3.12.10/config.json:42-44
The file is missing a trailing newline. Most editors and POSIX tools expect text files to end with a newline, and the absence is flagged by `git diff` with `\ No newline at end of file`.

```suggestion
    "overrides": {}
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert MILAB-6205: freesasa 2.2.1 (Windo..."](https://github.com/platforma-open/runenv-python-3/commit/2ea1aa1b7c4731be6c41e5d4ebb5e37a4f139101) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35155489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->