### PR TITLE
PFrames update

### DIFF
--- a/.changeset/fifty-donkeys-dig.md
+++ b/.changeset/fifty-donkeys-dig.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames update

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.40",
+      "polars-pf==1.1.43",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Bumps the `polars-pf` (PFrames) dependency from `1.1.40` to `1.1.43` in the Python 3.12.10 run environment, accompanied by a changeset entry marking this as a patch release.

- `python-3.12.10/config.json`: `polars-pf` version updated from `1.1.40` → `1.1.43`; all other dependencies are untouched.
- `.changeset/fifty-donkeys-dig.md`: new changeset file marking the package `@platforma-open/milaboratories.runenv-python-3.12.10` as a patch bump.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A targeted single-dependency patch bump with a matching changeset; no other dependencies or logic are touched.

The change is limited to advancing polars-pf by three patch versions. The rest of the dependency list is untouched, and the changeset correctly classifies this as a patch release.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fifty-donkeys-dig.md | New changeset file documenting the polars-pf version bump as a patch release for the python-3.12.10 runenv package. |
| python-3.12.10/config.json | Bumps polars-pf from 1.1.40 to 1.1.43; all other dependencies remain unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: PFrames update] --> B[python-3.12.10/config.json]
    A --> C[.changeset/fifty-donkeys-dig.md]
    B --> D[polars-pf: 1.1.40 → 1.1.43]
    C --> E[Patch release marker for\n@platforma-open/milaboratories.runenv-python-3.12.10]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames update"](https://github.com/platforma-open/runenv-python-3/commit/8e42d94f9f8c35fb3e51dbf2f010a6f45f8d0717) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36151826)</sub>

<!-- /greptile_comment -->