### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/five-papayas-decide.md
+++ b/.changeset/five-papayas-decide.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.43",
+      "polars-pf==1.1.49",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the `polars-pf` dependency from `1.1.43` to `1.1.49` in the Python 3.12.10 runtime environment and adds the accompanying Changesets patch entry.

- **`polars-pf`** (`1.1.43` → `1.1.49`): The PFrames integration package for Polars, providing PlatForma-specific DataFrame/Series extensions used across bioinformatics pipelines. Six patch versions are being absorbed in a single jump, classified as a `patch` release of the run-environment itself.
- **Changeset (`five-papayas-decide.md`)**: A Changesets tracking file that declares this change as a `patch` bump for the `@platforma-open/milaboratories.runenv-python-3.12.10` package, which drives automated changelog generation and version publishing.
- **`config.json` `dependencies`**: The pinned dependency list for the Python 3.12.10 runtime. All other pins remain unchanged; only `polars-pf` is updated.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A single dependency version bump with no other changes; low risk as long as polars-pf 1.1.49 is compatible with the rest of the pinned stack.

Only one line changes in config.json — the polars-pf pin moves forward six patch versions. The changeset is correctly typed as patch. No other dependencies, build logic, or code are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Bumps polars-pf from 1.1.43 to 1.1.49; all other pins are unchanged. |
| .changeset/five-papayas-decide.md | New changeset declaring a patch release for milaboratories.runenv-python-3.12.10 with the PFrames bump note. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Build
    participant Config as config.json
    participant PyPI as PyPI
    participant Env as Python 3.12.10 Runtime

    CI->>Config: Read dependency pins
    Config-->>CI: "polars-pf==1.1.49 (was 1.1.43)"
    CI->>PyPI: "Download polars-pf==1.1.49"
    PyPI-->>CI: Wheel resolved
    CI->>Env: Install all pinned dependencies
    Env-->>CI: Runtime environment ready
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Build
    participant Config as config.json
    participant PyPI as PyPI
    participant Env as Python 3.12.10 Runtime

    CI->>Config: Read dependency pins
    Config-->>CI: "polars-pf==1.1.49 (was 1.1.43)"
    CI->>PyPI: "Download polars-pf==1.1.49"
    PyPI-->>CI: Wheel resolved
    CI->>Env: Install all pinned dependencies
    Env-->>CI: Runtime environment ready
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/6ad7aee0aeac2ed7eaeba0217bbf2cb013e0993d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38143925)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->