### PR TITLE
MILAB-6382: expose host NVIDIA driver via runtime envs

### DIFF
--- a/.changeset/lemon-pants-chew.md
+++ b/.changeset/lemon-pants-chew.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-rapids': minor
+---
+
+NVIDIA env vars

--- a/python-3.12.10-rapids/package.json
+++ b/python-3.12.10-rapids/package.json
@@ -22,7 +22,11 @@
             "registry": "platforma-open",
             "python-version": "3.12.10",
             "envVars": [
-              "RPY2_CFFI_MODE=ABI"
+              "RPY2_CFFI_MODE=ABI",
+              "NVIDIA_VISIBLE_DEVICES=all",
+              "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
+              "LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib",
+              "PATH=/usr/local/nvidia/bin:${PATH}"
             ],
             "roots": {
               "linux-x64": "./pydist/linux-x64",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four NVIDIA GPU environment variables to the `python-3.12.10-rapids` run environment so that Python processes can discover and use the host NVIDIA driver when running inside a GPU-enabled container.

- **`NVIDIA_VISIBLE_DEVICES=all`** and **`NVIDIA_DRIVER_CAPABILITIES=compute,utility`**: NVIDIA Container Runtime control variables that expose all GPU devices and mount CUDA compute + utility capabilities into the container.
- **`LD_LIBRARY_PATH`** and **`PATH`**: Prepend `/usr/local/nvidia/lib64`, `/usr/local/nvidia/lib`, and `/usr/local/nvidia/bin` so the linker and shell can find NVIDIA shared libraries and utilities. The `PATH` entry uses `${PATH}` variable interpolation — a pattern not previously used in any `envVars` field in this codebase, whose runtime support is unconfirmed. `LD_LIBRARY_PATH` does not reference its existing value and will overwrite any previously set paths.

**Key terms touched by this PR:**

| Term | Definition | Change |
|---|---|---|
| `envVars` | Array of `KEY=VALUE` strings in the `block-software` artifact spec; applied as environment variables when the run environment is activated by the Platforma runtime | Extended from 1 entry (`RPY2_CFFI_MODE`) to 5 entries; introduces variable interpolation (`${PATH}`) for the first time in this codebase |
| `NVIDIA_VISIBLE_DEVICES` | NVIDIA Container Runtime variable controlling which GPU devices are visible inside the container | Newly added as `all` — exposes every available GPU to the Python process |
| `NVIDIA_DRIVER_CAPABILITIES` | NVIDIA Container Runtime variable specifying which driver API surface areas (compute, utility, video, etc.) are mounted into the container | Newly added as `compute,utility` — enables CUDA compute and `nvidia-smi`-style utility access |
| `LD_LIBRARY_PATH` | Linux dynamic linker search path for shared libraries | Newly set to `/usr/local/nvidia/lib64:/usr/local/nvidia/lib`; overwrites any pre-existing value |
| `PATH` | Executable search path used by the shell and most launchers | Newly prepended with `/usr/local/nvidia/bin` using `${PATH}` interpolation — a pattern unverified for this JSON-based config format |

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is small but introduces a `${PATH}` interpolation pattern that has never appeared in any other `envVars` entry in this codebase; if the Platforma runtime sets environment variables as literal strings rather than through a shell, the Python run environment's `PATH` will be broken on every execution.

The `${PATH}` interpolation in `PATH=/usr/local/nvidia/bin:${PATH}` is the first of its kind across all `envVars` definitions in the repository. If the runtime simply calls setenv/putenv with the raw string, every binary lookup outside `/usr/local/nvidia/bin` will fail. This needs explicit confirmation before the package ships. Secondary concerns are the unconditional overwrite of `LD_LIBRARY_PATH` and the NVIDIA-only paths being applied to macOS and Windows roots.

python-3.12.10-rapids/package.json — specifically the `PATH` env var entry with `${PATH}` interpolation and the `LD_LIBRARY_PATH` overwrite need verification before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-rapids/package.json | Adds four NVIDIA GPU runtime env vars to expose the host driver; the `${PATH}` interpolation syntax is untested in this JSON context and could break the run environment if the runtime doesn't expand it. |
| .changeset/lemon-pants-chew.md | Standard changeset entry recording a minor version bump for the RAPIDS package; description is brief but accurate. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json block-software envVars] --> B{Runtime applies envVars}
    B -->|Literal string copy| C["PATH = /usr/local/nvidia/bin:\${PATH}\n⚠️ \${PATH} not expanded"]
    B -->|Literal string copy| D["LD_LIBRARY_PATH = /usr/local/nvidia/lib64:/usr/local/nvidia/lib\n⚠️ Pre-existing value overwritten"]
    B -->|Simple assignment| E["NVIDIA_VISIBLE_DEVICES = all"]
    B -->|Simple assignment| F["NVIDIA_DRIVER_CAPABILITIES = compute,utility"]
    C -->|If interpolation unsupported| G["❌ PATH broken — only nvidia/bin visible"]
    C -->|If interpolation supported| H["✅ nvidia/bin prepended to original PATH"]
    D --> I["NVIDIA libs findable by linker\n⚠️ Other LD paths dropped"]
    E --> J["Container Runtime exposes all GPUs"]
    F --> K["CUDA compute + utility APIs mounted"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json block-software envVars] --> B{Runtime applies envVars}
    B -->|Literal string copy| C["PATH = /usr/local/nvidia/bin:\${PATH}\n⚠️ \${PATH} not expanded"]
    B -->|Literal string copy| D["LD_LIBRARY_PATH = /usr/local/nvidia/lib64:/usr/local/nvidia/lib\n⚠️ Pre-existing value overwritten"]
    B -->|Simple assignment| E["NVIDIA_VISIBLE_DEVICES = all"]
    B -->|Simple assignment| F["NVIDIA_DRIVER_CAPABILITIES = compute,utility"]
    C -->|If interpolation unsupported| G["❌ PATH broken — only nvidia/bin visible"]
    C -->|If interpolation supported| H["✅ nvidia/bin prepended to original PATH"]
    D --> I["NVIDIA libs findable by linker\n⚠️ Other LD paths dropped"]
    E --> J["Container Runtime exposes all GPUs"]
    F --> K["CUDA compute + utility APIs mounted"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apython-3.12.10-rapids%2Fpackage.json%3A29%0A**%60%24%7BPATH%7D%60%20expansion%20not%20guaranteed%20in%20JSON%20%60envVars%60**%0A%0AEvery%20other%20%60envVars%60%20entry%20in%20this%20repo%20is%20a%20plain%20%60KEY%3DVALUE%60%20literal%20with%20no%20variable%20references.%20If%20the%20Platforma%20runtime%20sets%20these%20strings%20directly%20%28e.g.%20via%20%60setenv%60%29%20rather%20than%20passing%20them%20through%20a%20shell%2C%20%60PATH%60%20will%20be%20set%20to%20the%20literal%20string%20%60%2Fusr%2Flocal%2Fnvidia%2Fbin%3A%24%7BPATH%7D%60%20%E2%80%94%20with%20the%20unexpanded%20text%20%60%24%7BPATH%7D%60%20as%20the%20suffix.%20That%20would%20break%20resolution%20of%20every%20binary%20%28including%20%60python%60%20itself%29%20that%20lives%20outside%20%60%2Fusr%2Flocal%2Fnvidia%2Fbin%60%2C%20making%20the%20entire%20run%20environment%20non-functional.%20Please%20confirm%20that%20the%20runtime%20performs%20%60%24%7B...%7D%60%20interpolation%20before%20applying%20%60envVars%60%2C%20or%20replace%20this%20entry%20with%20a%20fully%20resolved%20static%20path.%0A%0A%23%23%23%20Issue%202%20of%203%0Apython-3.12.10-rapids%2Fpackage.json%3A28-29%0A**NVIDIA%20runtime%20vars%20applied%20to%20all%20platforms%20including%20macOS%20and%20Windows**%0A%0A%60NVIDIA_VISIBLE_DEVICES%60%2C%20%60NVIDIA_DRIVER_CAPABILITIES%60%2C%20and%20the%20%60%2Fusr%2Flocal%2Fnvidia%2F...%60%20paths%20are%20NVIDIA%20Container%20Runtime%20constructs%20that%20are%20only%20meaningful%20in%20Linux%20containers%20with%20GPU%20passthrough.%20The%20%60roots%60%20in%20this%20package%20include%20%60macosx-x64%60%2C%20%60macosx-aarch64%60%2C%20and%20%60windows-x64%60.%20On%20those%20platforms%20the%20paths%20won't%20exist%20and%20%60LD_LIBRARY_PATH%60%20will%20point%20to%20directories%20that%20are%20absent%2C%20potentially%20interfering%20with%20any%20loader%20that%20respects%20%60LD_LIBRARY_PATH%60%20on%20macOS%20%28%60DYLD_LIBRARY_PATH%60%20is%20the%20macOS%20equivalent%29.%20If%20RAPIDS%20GPU%20features%20are%20explicitly%20unsupported%20on%20non-Linux%20platforms%2C%20consider%20conditionally%20applying%20these%20vars%20only%20for%20Linux%20targets%20%28if%20the%20runtime%20supports%20platform-specific%20env%20vars%29%2C%20or%20document%20that%20the%20NVIDIA%20vars%20are%20no-ops%20on%20non-Linux%20platforms.%0A%0A%23%23%23%20Issue%203%20of%203%0Apython-3.12.10-rapids%2Fpackage.json%3A28%0A**%60LD_LIBRARY_PATH%60%20silently%20overwrites%20any%20pre-existing%20value**%0A%0AUnlike%20%60PATH%60%2C%20which%20at%20least%20attempts%20to%20incorporate%20the%20existing%20value%20via%20%60%24%7BPATH%7D%60%2C%20%60LD_LIBRARY_PATH%60%20is%20set%20to%20a%20fixed%20string.%20If%20the%20host%20container%20%28or%20any%20previously%20applied%20runenv%20layer%29%20already%20exports%20%60LD_LIBRARY_PATH%60%20entries%20%28e.g.%20CUDA%20toolkit%2C%20cuDNN%29%2C%20those%20entries%20will%20be%20silently%20dropped%2C%20potentially%20causing%20runtime%20linker%20failures%20for%20libraries%20that%20depend%20on%20them.%20Using%20the%20same%20%60%24%7BLD_LIBRARY_PATH%7D%60%20pattern%20keeps%20existing%20paths%20intact%20%E2%80%94%20assuming%20the%20runtime%20supports%20interpolation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22LD_LIBRARY_PATH%3D%2Fusr%2Flocal%2Fnvidia%2Flib64%3A%2Fusr%2Flocal%2Fnvidia%2Flib%3A%24%7BLD_LIBRARY_PATH%7D%22%2C%0A%60%60%60%0A%0A&repo=platforma-open%2Frunenv-python-3&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
python-3.12.10-rapids/package.json:29
**`${PATH}` expansion not guaranteed in JSON `envVars`**

Every other `envVars` entry in this repo is a plain `KEY=VALUE` literal with no variable references. If the Platforma runtime sets these strings directly (e.g. via `setenv`) rather than passing them through a shell, `PATH` will be set to the literal string `/usr/local/nvidia/bin:${PATH}` — with the unexpanded text `${PATH}` as the suffix. That would break resolution of every binary (including `python` itself) that lives outside `/usr/local/nvidia/bin`, making the entire run environment non-functional. Please confirm that the runtime performs `${...}` interpolation before applying `envVars`, or replace this entry with a fully resolved static path.

### Issue 2 of 3
python-3.12.10-rapids/package.json:28-29
**NVIDIA runtime vars applied to all platforms including macOS and Windows**

`NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`, and the `/usr/local/nvidia/...` paths are NVIDIA Container Runtime constructs that are only meaningful in Linux containers with GPU passthrough. The `roots` in this package include `macosx-x64`, `macosx-aarch64`, and `windows-x64`. On those platforms the paths won't exist and `LD_LIBRARY_PATH` will point to directories that are absent, potentially interfering with any loader that respects `LD_LIBRARY_PATH` on macOS (`DYLD_LIBRARY_PATH` is the macOS equivalent). If RAPIDS GPU features are explicitly unsupported on non-Linux platforms, consider conditionally applying these vars only for Linux targets (if the runtime supports platform-specific env vars), or document that the NVIDIA vars are no-ops on non-Linux platforms.

### Issue 3 of 3
python-3.12.10-rapids/package.json:28
**`LD_LIBRARY_PATH` silently overwrites any pre-existing value**

Unlike `PATH`, which at least attempts to incorporate the existing value via `${PATH}`, `LD_LIBRARY_PATH` is set to a fixed string. If the host container (or any previously applied runenv layer) already exports `LD_LIBRARY_PATH` entries (e.g. CUDA toolkit, cuDNN), those entries will be silently dropped, potentially causing runtime linker failures for libraries that depend on them. Using the same `${LD_LIBRARY_PATH}` pattern keeps existing paths intact — assuming the runtime supports interpolation.

```suggestion
              "LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib:${LD_LIBRARY_PATH}",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6382: expose host NVIDIA driver vi..."](https://github.com/platforma-open/runenv-python-3/commit/92eae77bc8a18b5194a55264127e54aefc66528a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38174985)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->