### PR TITLE
Fix whitelists on windows

### DIFF
--- a/.changeset/all-candies-repeat.md
+++ b/.changeset/all-candies-repeat.md
@@ -1,0 +1,7 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+'@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': patch
+'@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': patch
+---
+
+Fix whitelists on windows

--- a/checker/whitelists/python-3.12.10-h5ad/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-h5ad/windows-x64.json
@@ -1,13 +1,6 @@
 {
   "matplotlib-3.*-cp312-cp312-win_amd64.whl": {
-    "matplotlib._c_internal_utils": "Could not determine home directory",
-    "matplotlib._image": "Could not determine home directory",
-    "matplotlib._path": "Could not determine home directory",
-    "matplotlib._qhull": "Could not determine home directory",
-    "matplotlib._tri": "Could not determine home directory",
-    "matplotlib.backends._backend_agg": "Could not determine home directory",
-    "matplotlib.backends._tkagg": "Could not determine home directory",
-    "matplotlib.ft2font": "Could not determine home directory"
+    "matplotlib.backends._tkagg": "Failed to load Tcl_SetVar or Tcl_SetVar2"
   },
   "numba-0.*-win_amd64.whl": {
     "numba.np.ufunc.tbbpool": "DLL load failed while importing tbbpool: The specified module could not be found"

--- a/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
+++ b/checker/whitelists/python-3.12.10-sccoda/windows-x64.json
@@ -3,14 +3,7 @@
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "matplotlib-3.*-cp312-cp312-win_amd64.whl": {
-    "matplotlib._c_internal_utils": "Could not determine home directory",
-    "matplotlib._image": "Could not determine home directory",
-    "matplotlib._path": "Could not determine home directory",
-    "matplotlib._qhull": "Could not determine home directory",
-    "matplotlib._tri": "Could not determine home directory",
-    "matplotlib.backends._backend_agg": "Could not determine home directory",
-    "matplotlib.backends._tkagg": "Could not determine home directory",
-    "matplotlib.ft2font": "Could not determine home directory"
+    "matplotlib.backends._tkagg": "Failed to load Tcl_SetVar or Tcl_SetVar2"
   },
   "numpy-1.26.4-cp312-cp312-win_amd64.whl": {
     "numpy.core._umath_tests": "cannot load _umath_tests module"

--- a/checker/whitelists/python-3.12.10/windows-x64.json
+++ b/checker/whitelists/python-3.12.10/windows-x64.json
@@ -3,14 +3,7 @@
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "matplotlib-3.*-cp312-cp312-win_amd64.whl": {
-    "matplotlib._c_internal_utils": "Could not determine home directory",
-    "matplotlib._image": "Could not determine home directory",
-    "matplotlib._path": "Could not determine home directory",
-    "matplotlib._qhull": "Could not determine home directory",
-    "matplotlib._tri": "Could not determine home directory",
-    "matplotlib.backends._backend_agg": "Could not determine home directory",
-    "matplotlib.backends._tkagg": "Could not determine home directory",
-    "matplotlib.ft2font": "Could not determine home directory"
+    "matplotlib.backends._tkagg": "Failed to load Tcl_SetVar or Tcl_SetVar2"
   },
   "numba-0.*-win_amd64.whl": {
     "numba.np.ufunc.tbbpool": "DLL load failed while importing tbbpool: The specified module could not be found"


### PR DESCRIPTION
Fixing errors of https://github.com/platforma-open/runenv-python-3/actions/runs/27696123144/job/81934866371 build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Windows x64 import-error whitelists for three Python 3.12.10 environment variants to fix a failing CI build. The old entries whitelisted 8 matplotlib submodule failures all attributed to "Could not determine home directory"; the new entries replace them with a single `matplotlib.backends._tkagg` failure whose actual error is "Failed to load Tcl_SetVar or Tcl_SetVar2".

- **Whitelist narrowing**: 7 previously-whitelisted matplotlib import errors (`_c_internal_utils`, `_image`, `_path`, `_qhull`, `_tri`, `_backend_agg`, `ft2font`) are removed. These were likely cascade failures triggered by the missing-home-directory condition, which has since been resolved in the CI environment.
- **Remaining exception**: Only `matplotlib.backends._tkagg` stays whitelisted, now with the more precise Tcl/Tk DLL error that reflects the actual runtime environment on Windows.
- **Changeset**: A `patch` bump is recorded for all three packages (`python-3.12.10`, `python-3.12.10-h5ad`, `python-3.12.10-sccoda`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the whitelist files now accurately reflect the actual import errors observed in the Windows CI environment.

The change removes 7 matplotlib whitelist entries whose root cause ("Could not determine home directory") no longer occurs in the CI environment, and replaces them with the one entry that does: a Tcl/Tk DLL load failure for `matplotlib.backends._tkagg`. The narrower whitelist is strictly more correct — it no longer silently accepts errors that are no longer expected. All three environment variants (base, h5ad, sccoda) are updated consistently, and the changeset bumps each package at patch level.

No files require special attention. All three whitelist JSON files make the same targeted change and the changeset covers them all.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| checker/whitelists/python-3.12.10/windows-x64.json | Replaces 8 "Could not determine home directory" matplotlib entries with a single tkagg Tcl error; all other entries unchanged. |
| checker/whitelists/python-3.12.10-h5ad/windows-x64.json | Same matplotlib whitelist narrowing as the base variant; numba and scipy entries retained. |
| checker/whitelists/python-3.12.10-sccoda/windows-x64.json | Same matplotlib whitelist narrowing as the base variant; numpy, numba, rpy2, and scipy entries retained. |
| .changeset/all-candies-repeat.md | Patch-level changeset correctly covering all three affected packages. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: Import checker runs on Windows x64] --> B{matplotlib wheel imports}
    B -->|Before PR| C["8 modules fail\n'Could not determine home directory'"]
    B -->|After PR| D["1 module fails\nmatplotlib.backends._tkagg\n'Failed to load Tcl_SetVar or Tcl_SetVar2'"]
    C --> E[All 8 whitelisted\nin windows-x64.json]
    D --> F[Only tkagg whitelisted\nin windows-x64.json]
    E --> G["CI passes\n(but whitelist is over-broad)"]
    F --> H["CI passes\n(whitelist matches actual errors)"]
    C -->|Home directory issue resolved| D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CI: Import checker runs on Windows x64] --> B{matplotlib wheel imports}
    B -->|Before PR| C["8 modules fail\n'Could not determine home directory'"]
    B -->|After PR| D["1 module fails\nmatplotlib.backends._tkagg\n'Failed to load Tcl_SetVar or Tcl_SetVar2'"]
    C --> E[All 8 whitelisted\nin windows-x64.json]
    D --> F[Only tkagg whitelisted\nin windows-x64.json]
    E --> G["CI passes\n(but whitelist is over-broad)"]
    F --> H["CI passes\n(whitelist matches actual errors)"]
    C -->|Home directory issue resolved| D
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix whitelists on windows"](https://github.com/platforma-open/runenv-python-3/commit/f487928ae3c14d35acbb3405d600d835b4ad9287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38344971)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->