### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/fast-candies-do.md
+++ b/.changeset/fast-candies-do.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.49",
+      "polars-pf==1.1.51",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `polars-pf` Python package from `1.1.49` to `1.1.51` in the Python 3.12.10 environment configuration and adds the corresponding changeset entry for a patch release.

- **`polars-pf`** (`python-3.12.10/config.json`): Version incremented from `1.1.49` → `1.1.51` (skips `1.1.50`), picking up two patch releases of the PFrames Polars integration.
- **`fast-candies-do.md`** (`.changeset/`): New changeset file declaring this as a `patch`-level release for `@platforma-open/milaboratories.runenv-python-3.12.10`.

**Touched Terms:**

| Term | Definition | Change |
|---|---|---|
| `polars-pf` | Python package providing PFrames (Platforma Frames) integration with the Polars dataframe library, enabling columnar data exchange between Platforma workflows and Python analysis code. | Bumped from `1.1.49` to `1.1.51`, incorporating two patch releases upstream. |
| **PFrames** | The Platforma Frames data format/abstraction — a typed, columnar data container used to pass structured table data between workflow steps (blocks) in the Platforma platform. | Indirectly updated via the `polars-pf` package upgrade. |
| `patch` (changeset type) | Semantic versioning category for backward-compatible bug fixes or minor dependency bumps, as defined by the Changesets versioning workflow. | Correctly categorised as `patch` since only an internal dependency version is bumped with no API surface change. |

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A single-line dependency pin update with a correctly typed changeset — safe to merge.

Only one dependency (polars-pf) changes, moving from 1.1.49 to 1.1.51. The changeset correctly marks this as a patch release. No configuration structure, build logic, or other packages are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fast-candies-do.md | New changeset file declaring a patch release for the @platforma-open/milaboratories.runenv-python-3.12.10 package with a "PFrames bump" message. |
| python-3.12.10/config.json | Bumps polars-pf dependency from 1.1.49 to 1.1.51; all other dependencies remain unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[python-3.12.10/config.json] -->|declares dependency| B["polars-pf==1.1.51\n(was 1.1.49)"]
    B -->|provides| C[PFrames ↔ Polars integration]
    C -->|used by| D[Python workflow blocks]
    E[.changeset/fast-candies-do.md] -->|triggers patch release for| F["@platforma-open/milaboratories\n.runenv-python-3.12.10"]
    A -.->|versioned by| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[python-3.12.10/config.json] -->|declares dependency| B["polars-pf==1.1.51\n(was 1.1.49)"]
    B -->|provides| C[PFrames ↔ Polars integration]
    C -->|used by| D[Python workflow blocks]
    E[.changeset/fast-candies-do.md] -->|triggers patch release for| F["@platforma-open/milaboratories\n.runenv-python-3.12.10"]
    A -.->|versioned by| E
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/4a3167b757bca2ffdc6f986ff09d89cae5d298f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38417831)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->