### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/late-cameras-find.md
+++ b/.changeset/late-cameras-find.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.51",
+      "polars-pf==1.1.53",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `polars-pf` dependency from `1.1.51` to `1.1.53` in the Python 3.12.10 runtime environment, with a corresponding changeset entry marking it as a patch release.

- **`polars-pf` version bump** (`python-3.12.10/config.json`): Increments `polars-pf` (the PFrames–Polars bridge package) by two patch versions (1.1.51 → 1.1.53). All other pinned dependencies remain unchanged.
- **Changeset** (`.changeset/late-cameras-find.md`): Records the change as a `patch` bump for `@platforma-open/milaboratories.runenv-python-3.12.10`, following the repository's Changesets versioning workflow.

**Touched terms:**
- **`polars-pf`** — Python package providing PFrame (Platforma Frame) support for the Polars analytics library. Updated from `1.1.51` → `1.1.53`.
- **PFrame** (Platforma Frame) — Core data structure type in the Platforma codebase representing a structured, typed data frame following Platforma's data model. `polars-pf` is the Python runtime bridge enabling PFrame operations via Polars; this bump pulls in two patch-level PFrame fixes/improvements.
- **`@platforma-open/milaboratories.runenv-python-3.12.10`** — Package identifier for the Python 3.12.10 runtime environment definition. Receives a patch version increment in the changeset to reflect the dependency update.
- **changeset** — A file in `.changeset/` that declares a pending version change as part of the Changesets workflow. A new entry (`late-cameras-find.md`) is added here to record this patch bump.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A straightforward two-patch-version bump of a single dependency with a matching changeset entry — no logic changes, no schema changes, no other dependencies affected.

The change is a single-line version pin update for polars-pf (1.1.51 → 1.1.53) and a new changeset file. All other dependencies remain pinned at their current versions, and the changeset correctly marks this as a patch release for the runtime environment package.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Bumps polars-pf dependency from 1.1.51 to 1.1.53 (patch release) in the Python 3.12.10 runtime environment dependency list |
| .changeset/late-cameras-find.md | New changeset file documenting the polars-pf bump as a patch-level release for @platforma-open/milaboratories.runenv-python-3.12.10 |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[python-3.12.10/config.json] --> B[polars-pf dependency]
    B -- "was 1.1.51" --> C[Old Version]
    B -- "now 1.1.53" --> D[New Version]
    E[.changeset/late-cameras-find.md] --> F["@platforma-open/milaboratories.runenv-python-3.12.10 : patch"]
    F --> G[Changesets versioning workflow]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[python-3.12.10/config.json] --> B[polars-pf dependency]
    B -- "was 1.1.51" --> C[Old Version]
    B -- "now 1.1.53" --> D[New Version]
    E[.changeset/late-cameras-find.md] --> F["@platforma-open/milaboratories.runenv-python-3.12.10 : patch"]
    F --> G[Changesets versioning workflow]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/3716467b1a5046a85f89f0f33942fead0c7e284e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39501551)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->