### PR TITLE
Include dependencies needed for the new sequence embedding models

### DIFF
--- a/.changeset/torch-cuda-ablang2-sceptr.md
+++ b/.changeset/torch-cuda-ablang2-sceptr.md
@@ -1,0 +1,11 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': minor
+---
+
+Add antibody (AbLang2) and TCR (SCEPTR) specialist embedding libraries plus rdkit to the torch-cuda run environment.
+
+- `ablang2==0.2.1` — AbLang2 antibody language model (pulls einops + rotary-embedding-torch)
+- `sceptr==1.2.0` — SCEPTR paired-chain TCR model (pulls libtcrlm + tidytcells + pandas + blosum)
+- `rdkit==2026.3.3` — cheminformatics toolkit for the PeptideCLM-2 amino-acid→SMILES conversion (pulls Pillow)
+
+All install conflict-free on top of the existing pins (transformers 4.53.2, polars-lts-cpu 1.33.1, numpy 2.2.6, pyarrow 21.0.0, torch 2.7.0); `pip check` clean.

--- a/checker/whitelists/linux-x64.json
+++ b/checker/whitelists/linux-x64.json
@@ -185,6 +185,9 @@
   "pynvjitlink_cu12-0.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl": {
     "pynvjitlink._nvjitlinklib": "libcuda.so.1: cannot open shared object file: No such file or directory"
   },
+  "rdkit-2026.3.3-cp312-cp312-manylinux_2_28_x86_64.whl": {
+    "rdkit.Chem.Draw.rdMolDraw2D": "libXrender.so.1: cannot open shared object file: No such file or directory"
+  },
   "scipy-1.*.whl": {
     "scipy.linalg._matfuncs_sqrtm_triu": "cannot import name 'within_block_loop' from partially initialized module",
     "scipy.stats._unuran.unuran_wrapper": "module 'numpy.random.bit_generator' has no attribute 'SeedlessSequence'"
@@ -201,6 +204,10 @@
   },
   "torch-2.9.1+cpu-cp312-cp312-manylinux_2_28_x86_64.whl": {
     "functorch._C": "initialization failed"
+  },
+  "torch-2.12.1+cu126-cp312-cp312-manylinux_2_28_x86_64.whl": {
+    "functorch._C": "initialization failed",
+    "torch.lib.libcaffe2_nvrtc": "libcuda.so.1: cannot open shared object file"
   },
   "torchaudio-2.7.0+cpu-cp312-cp312-manylinux_2_28_x86_64.whl": {
     "torchaudio.lib._torchaudio_sox": "libtorchaudio_sox.so: cannot open shared object file: No such file or directory",

--- a/python-3.12.10-torch-cuda/config.json
+++ b/python-3.12.10-torch-cuda/config.json
@@ -9,7 +9,10 @@
       "transformers==4.53.2",
       "polars-lts-cpu==1.33.1",
       "numpy==2.2.6",
-      "pyarrow==21.0.0"
+      "pyarrow==21.0.0",
+      "ablang2==0.2.1",
+      "sceptr==1.2.0",
+      "rdkit==2026.3.3"
     ],
     "platformSpecific": {
       "linux-x64": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the `python-3.12.10-torch-cuda` run environment with three pinned sequence-embedding libraries — `ablang2==0.2.1` (antibody language model), `sceptr==1.2.0` (TCR model), and `rdkit==2026.3.3` (cheminformatics toolkit for PeptideCLM-2) — along with a matching changeset entry.

- **`python-3.12.10-torch-cuda/config.json`**: Three new entries appended to the `dependencies` array; the existing pins (transformers, polars-lts-cpu, numpy, pyarrow, torch) are untouched.
- **`.changeset/torch-cuda-ablang2-sceptr.md`**: Minor-version changeset documenting the additions and explicitly noting `pip check` was run to confirm no conflicts.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Adding three pinned libraries to the torch-cuda environment is a low-risk, additive change; the existing pins are untouched and the author notes pip check passed.

The change is purely additive — three new version-pinned packages in one environment's dependency list. The transitive dependencies (einops, rotary-embedding-torch, libtcrlm, tidytcells, pandas, blosum, Pillow) are not themselves pinned in config.json, so future pip resolves could pull in different transitive versions. The changeset documents the rationale clearly and claims pip check is clean, but that validation is not reproducible from the diff alone.

The only non-trivial file is `python-3.12.10-torch-cuda/config.json`. Transitive dependencies of the three new packages are not pinned, which could cause unexpected resolution changes in the future.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-torch-cuda/config.json | Adds three new pinned dependencies (ablang2==0.2.1, sceptr==1.2.0, rdkit==2026.3.3) to the torch-cuda run environment; all are version-pinned and claimed conflict-free per pip check. |
| .changeset/torch-cuda-ablang2-sceptr.md | New changeset file documenting the minor version bump for the torch-cuda environment with clear description of added packages and their transitive dependencies. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph env["python-3.12.10-torch-cuda environment"]
        direction TB
        existing["Existing pins\ntransformers==4.53.2\npolars-lts-cpu==1.33.1\nnumpy==2.2.6\npyarrow==21.0.0\ntorch==2.7.0+cu126 (linux-x64)\ntorch==2.7.0 (macosx-aarch64)"]
        new["New pins (this PR)\nablang2==0.2.1\nsceptr==1.2.0\nrdkit==2026.3.3"]
    end

    ablang2["ablang2==0.2.1\n(Antibody LM)"] -->|pulls| einops["einops"]
    ablang2 -->|pulls| rotary["rotary-embedding-torch"]

    sceptr["sceptr==1.2.0\n(TCR model)"] -->|pulls| libtcrlm["libtcrlm"]
    sceptr -->|pulls| tidytcells["tidytcells"]
    sceptr -->|pulls| pandas["pandas"]
    sceptr -->|pulls| blosum["blosum"]

    rdkit["rdkit==2026.3.3\n(Cheminformatics)"] -->|pulls| Pillow["Pillow"]

    new --> ablang2
    new --> sceptr
    new --> rdkit
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph env["python-3.12.10-torch-cuda environment"]
        direction TB
        existing["Existing pins\ntransformers==4.53.2\npolars-lts-cpu==1.33.1\nnumpy==2.2.6\npyarrow==21.0.0\ntorch==2.7.0+cu126 (linux-x64)\ntorch==2.7.0 (macosx-aarch64)"]
        new["New pins (this PR)\nablang2==0.2.1\nsceptr==1.2.0\nrdkit==2026.3.3"]
    end

    ablang2["ablang2==0.2.1\n(Antibody LM)"] -->|pulls| einops["einops"]
    ablang2 -->|pulls| rotary["rotary-embedding-torch"]

    sceptr["sceptr==1.2.0\n(TCR model)"] -->|pulls| libtcrlm["libtcrlm"]
    sceptr -->|pulls| tidytcells["tidytcells"]
    sceptr -->|pulls| pandas["pandas"]
    sceptr -->|pulls| blosum["blosum"]

    rdkit["rdkit==2026.3.3\n(Cheminformatics)"] -->|pulls| Pillow["Pillow"]

    new --> ablang2
    new --> sceptr
    new --> rdkit
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apython-3.12.10-torch-cuda%2Fconfig.json%3A13-15%0A**Transitive%20dependencies%20not%20pinned**%0A%0A%60ablang2%60%2C%20%60sceptr%60%2C%20and%20%60rdkit%60%20each%20pull%20in%20several%20transitive%20packages%20%28%60einops%60%2C%20%60rotary-embedding-torch%60%2C%20%60libtcrlm%60%2C%20%60tidytcells%60%2C%20%60pandas%60%2C%20%60blosum%60%2C%20%60Pillow%60%29%20that%20are%20not%20pinned%20here.%20A%20future%20%60pip%60%20resolve%20could%20silently%20upgrade%20any%20of%20them%20and%20introduce%20an%20ABI%20or%20API%20mismatch%20with%20the%20pinned%20%60numpy%3D%3D2.2.6%60%20or%20%60torch%3D%3D2.7.0%60%20in%20this%20same%20environment.%20Consider%20adding%20explicit%20pins%20for%20the%20key%20transitives%20%E2%80%94%20especially%20%60pandas%60%20%28which%20has%20historically%20broken%20APIs%20across%20minor%20versions%29%20%E2%80%94%20either%20directly%20in%20this%20array%20or%20via%20a%20%60constraints.txt%60%20%2F%20lock%20file.%0A%0A&repo=platforma-open%2Frunenv-python-3&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
python-3.12.10-torch-cuda/config.json:13-15
**Transitive dependencies not pinned**

`ablang2`, `sceptr`, and `rdkit` each pull in several transitive packages (`einops`, `rotary-embedding-torch`, `libtcrlm`, `tidytcells`, `pandas`, `blosum`, `Pillow`) that are not pinned here. A future `pip` resolve could silently upgrade any of them and introduce an ABI or API mismatch with the pinned `numpy==2.2.6` or `torch==2.7.0` in this same environment. Consider adding explicit pins for the key transitives — especially `pandas` (which has historically broken APIs across minor versions) — either directly in this array or via a `constraints.txt` / lock file.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Include dependencies needed for the new ..."](https://github.com/platforma-open/runenv-python-3/commit/06121fdfda1b13899d6484efd35f37e69716deff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39531963)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->