### PR TITLE
Add OLGA runenv

### DIFF
--- a/.changeset/pgen-runenv.md
+++ b/.changeset/pgen-runenv.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-pgen': minor
+'@platforma-open/milaboratories.runenv-python-3': minor
+---
+
+Add Python 3.12.10 run environment for the Generation Probability block: olga (CDR3 generation probability + its bundled recombination models) with numpy and polars-lts-cpu. macOS-Intel is not built (no llvmlite cp312 wheel).

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,6 +108,11 @@ jobs:
           {"os":"macos-15-large", "arch":"amd64", "selector":"./python-3.12.10-clustering"},
           {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-clustering"},
 
+          {"os":"ubuntu-large-arm64", "arch":"arm64", "selector":"./python-3.12.10-pgen"},
+          {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-pgen"},
+          {"os":"macos-15", "arch":"arm64", "selector":"./python-3.12.10-pgen"},
+          {"os":"windows-latest", "arch":"amd64", "selector":"./python-3.12.10-pgen"},
+
           {"os":"ubuntu-large-amd64", "arch":"amd64", "selector":"./python-3.12.10-torch-cuda"},
           {"os":"macos-15", "arch":"arm64", "selector":"./python-3.12.10-torch-cuda"}
         ]

--- a/catalogue/package.json
+++ b/catalogue/package.json
@@ -41,6 +41,9 @@
       },
       "3.12.10-clustering": {
         "reference": "@platforma-open/milaboratories.runenv-python-3.12.10-clustering/dist/tengo/software/main.sw.json"
+      },
+      "3.12.10-pgen": {
+        "reference": "@platforma-open/milaboratories.runenv-python-3.12.10-pgen/dist/tengo/software/main.sw.json"
       }
     }
   },
@@ -58,7 +61,8 @@
     "@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim": "workspace:*",
     "@platforma-open/milaboratories.runenv-python-3.12.10-humanness": "workspace:*",
     "@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda": "workspace:*",
-    "@platforma-open/milaboratories.runenv-python-3.12.10-clustering": "workspace:*"
+    "@platforma-open/milaboratories.runenv-python-3.12.10-clustering": "workspace:*",
+    "@platforma-open/milaboratories.runenv-python-3.12.10-pgen": "workspace:*"
   },
   "devDependencies": {
     "@platforma-sdk/package-builder": "catalog:"

--- a/checker/whitelists/macosx-aarch64.json
+++ b/checker/whitelists/macosx-aarch64.json
@@ -3,7 +3,7 @@
     "81d243bd2c585b0f4821__mypyc": "invalid decimal literal"
   },
   "numba-0.*-macosx_*_arm64.whl": {
-    "numba.np.ufunc.omppool": "'/Users/runner/miniconda3/envs/test/lib/libomp.dylib' (no such file)"
+    "numba.np.ufunc.omppool": "Reason: no LC_RPATH's found"
   },
   "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl": {
     "numpy.core._umath_tests": "cannot load _umath_tests module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred':
         specifier: workspace:*
         version: link:../python-3.12.10-parapred
+      '@platforma-open/milaboratories.runenv-python-3.12.10-pgen':
+        specifier: workspace:*
+        version: link:../python-3.12.10-pgen
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids':
         specifier: workspace:*
         version: link:../python-3.12.10-rapids
@@ -167,6 +170,18 @@ importers:
         version: 4.20.6
 
   python-3.12.10-parapred:
+    devDependencies:
+      '@platforma-sdk/package-builder':
+        specifier: 'catalog:'
+        version: 3.10.7
+      runenv-python-builder:
+        specifier: workspace:*
+        version: link:../builder
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.6
+
+  python-3.12.10-pgen:
     devDependencies:
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - python-3.12.10-humanness
   - python-3.12.10-torch-cuda
   - python-3.12.10-clustering
+  - python-3.12.10-pgen
   - catalogue
 
 catalog:

--- a/python-3.12.10-pgen/CHANGELOG.md
+++ b/python-3.12.10-pgen/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @platforma-open/milaboratories.runenv-python-3.12.10-pgen

--- a/python-3.12.10-pgen/README.md
+++ b/python-3.12.10-pgen/README.md
@@ -1,0 +1,3 @@
+Python 3.12.10 run environment for the Generation Probability block (`generation-probability`): `olga` (V(D)J generation-probability computation for CDR3s, including its 10 bundled recombination models) plus `numpy` and `polars-lts-cpu` for Parquet I/O, and transitives.
+
+Note: olga declares `numba` as a hard dependency (pulling `llvmlite`/LLVM), so these are bundled even though the block only uses olga's pure-NumPy `compute_aa_CDR3_pgen` path, not olga's numba fast-path. macOS-Intel (`macosx-x64`) is intentionally not built — `llvmlite` ships no cp312 wheel for that platform.

--- a/python-3.12.10-pgen/config.json
+++ b/python-3.12.10-pgen/config.json
@@ -1,0 +1,13 @@
+{
+  "packages": {
+    "dependencies": [
+      "olga==1.3.0",
+      "polars-lts-cpu==1.33.1",
+      "numpy==2.2.6"
+    ],
+    "skip": {},
+    "overrides": {},
+    "platformSpecific": {},
+    "buildWheel": {}
+  }
+}

--- a/python-3.12.10-pgen/package.json
+++ b/python-3.12.10-pgen/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@platforma-open/milaboratories.runenv-python-3.12.10-pgen",
+  "version": "0.1.0",
+  "description": "Python 3.12.10 run environment for the Generation Probability block (olga for CDR3 generation probability + numpy + polars-lts-cpu)",
+  "scripts": {
+    "cleanup": "rm -rf ./pkg-*.tgz ./pydist ./dist/ ./build/",
+    "reset": "pnpm run cleanup && rm -rf ./node_modules ./.turbo",
+    "build": "pl-py-builder",
+    "after-prebuild": "pl-pkg publish packages",
+    "before-publish": "pl-pkg prepublish"
+  },
+  "files": [
+    "dist/"
+  ],
+  "block-software": {
+    "entrypoints": {
+      "main": {
+        "environment": {
+          "artifact": {
+            "type": "environment",
+            "runtime": "python",
+            "registry": "platforma-open",
+            "python-version": "3.12.10",
+            "roots": {
+              "linux-x64": "./pydist/linux-x64",
+              "linux-aarch64": "./pydist/linux-aarch64",
+              "macosx-aarch64": "./pydist/macosx-aarch64",
+              "windows-x64": "./pydist/windows-x64"
+            },
+            "binDir": "bin"
+          }
+        }
+      }
+    }
+  },
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "@platforma-sdk/package-builder": "catalog:",
+    "runenv-python-builder": "workspace:*",
+    "tsx": "catalog:"
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Python 3.12.10 run environment (`python-3.12.10-pgen`) targeting the Generation Probability (`pgen`) block, bundling `olga` for V(D)J CDR3 generation probability, `numpy`, and `polars-lts-cpu`. The package is correctly wired into the monorepo workspace, catalogue, and pnpm lockfile.

- **New runenv package** (`python-3.12.10-pgen`): declares `olga==1.3.0`, `polars-lts-cpu==1.33.1`, and `numpy==2.2.6` as pip dependencies; builds for `linux-x64`, `linux-aarch64`, `macosx-aarch64`, and `windows-x64` only — `macosx-x64` is intentionally omitted from roots because no `llvmlite` cp312 wheel exists for that platform.
- **Catalogue registration**: the `3.12.10-pgen` entrypoint and `workspace:*` dependency are added to `catalogue/package.json`, following the same pattern as all existing runenvs.
- **Changeset**: marks a `minor` bump for both the new package and the `runenv-python-3` catalogue, consistent with the project's versioning conventions.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a purely additive change that introduces a new isolated runenv package without touching any existing build logic.

All registration steps (workspace, catalogue entrypoint, catalogue dependency, lockfile) are correctly wired and follow the same conventions as existing runenvs. The intentional omission of macosx-x64 from roots mirrors the torch-cuda package approach and is clearly documented. Dependencies are pinned to specific versions. No existing packages are modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-pgen/config.json | Declares pip dependencies (olga, polars-lts-cpu, numpy) with pinned versions; skip/overrides/platformSpecific/buildWheel are all empty objects, matching the template pattern used by other runenvs. |
| python-3.12.10-pgen/package.json | Package metadata and block-software artifact declaration; correctly omits macosx-x64 from roots (same pattern as python-3.12.10-torch-cuda) to reflect the intentional platform exclusion due to missing llvmlite cp312 wheel. |
| catalogue/package.json | Adds 3.12.10-pgen block-software entrypoint and workspace dependency; follows exact same structure as all other runenv entries. |
| pnpm-workspace.yaml | Registers python-3.12.10-pgen as a workspace package; placed correctly between clustering and catalogue. |
| .changeset/pgen-runenv.md | Declares a minor version bump for both the new pgen package and the runenv-python-3 catalogue; changeset summary accurately describes the new environment and its platform constraints. |
| pnpm-lock.yaml | Lockfile correctly updated: adds pgen to the catalogue importer block and creates its own python-3.12.10-pgen importer entry with devDependencies only. |
| python-3.12.10-pgen/README.md | Documents the environment purpose, transitive numba/llvmlite bundling rationale, and macOS-Intel exclusion; clear and accurate. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm-workspace.yaml
python-3.12.10-pgen] --> B[python-3.12.10-pgen/package.json
v0.1.0]
    B --> C[python-3.12.10-pgen/config.json
dependencies: olga==1.3.0
polars-lts-cpu==1.33.1
numpy==2.2.6]
    B --> D{Platform roots}
    D --> E[linux-x64
./pydist/linux-x64]
    D --> F[linux-aarch64
./pydist/linux-aarch64]
    D --> G[macosx-aarch64
./pydist/macosx-aarch64]
    D --> H[windows-x64
./pydist/windows-x64]
    D -. intentionally omitted .-> I[macosx-x64
no llvmlite cp312 wheel]
    B --> J[catalogue/package.json
entrypoints: 3.12.10-pgen
dependencies: workspace:*]
    J --> K[block-software artifact
dist/tengo/software/main.sw.json]
    C --> L[transitive deps
numba + llvmlite
via olga]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm-workspace.yaml
python-3.12.10-pgen] --> B[python-3.12.10-pgen/package.json
v0.1.0]
    B --> C[python-3.12.10-pgen/config.json
dependencies: olga==1.3.0
polars-lts-cpu==1.33.1
numpy==2.2.6]
    B --> D{Platform roots}
    D --> E[linux-x64
./pydist/linux-x64]
    D --> F[linux-aarch64
./pydist/linux-aarch64]
    D --> G[macosx-aarch64
./pydist/macosx-aarch64]
    D --> H[windows-x64
./pydist/windows-x64]
    D -. intentionally omitted .-> I[macosx-x64
no llvmlite cp312 wheel]
    B --> J[catalogue/package.json
entrypoints: 3.12.10-pgen
dependencies: workspace:*]
    J --> K[block-software artifact
dist/tengo/software/main.sw.json]
    C --> L[transitive deps
numba + llvmlite
via olga]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add OLGA runenv"](https://github.com/platforma-open/runenv-python-3/commit/a07993fa774b9437ee9707f20074f441ca60320d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41596407)</sub>

<!-- /greptile_comment -->