### PR TITLE
Julenmendieta/MILAB-6501_bigEmbeddings

### DIFF
--- a/.changeset/add-hdbscan-python-3-12-10.md
+++ b/.changeset/add-hdbscan-python-3-12-10.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.runenv-python-3.12.10": patch
+---
+
+Add `hdbscan==0.8.44` (scikit-learn-contrib HDBSCAN) to the Python 3.12.10 runenv. Built from prebuilt wheels on linux-x64, macOS (universal2) and win-x64; compiled from the Cython sources on the native runner for linux-aarch64 (no ARM64 wheel on PyPI). Provides density-based clustering with out-of-sample assignment (`approximate_predict`), enabling the embedding-clustering block's large-dataset path.

--- a/.changeset/calm-crabs-type.md
+++ b/.changeset/calm-crabs-type.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+Add hdbscan

--- a/.changeset/calm-crabs-type.md
+++ b/.changeset/calm-crabs-type.md
@@ -1,5 +1,0 @@
----
-'@platforma-open/milaboratories.runenv-python-3.12.10': patch
----
-
-Add hdbscan

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -12,6 +12,7 @@
       "parasail==1.3.4",
       "numpy==2.2.6",
       "umap-learn==0.5.7",
+      "hdbscan==0.8.44",
       "PyYAML==6.0.3",
       "cudf-cu12==25.6.0",
       "scanpy==1.10.1",
@@ -70,6 +71,12 @@
         "windows-x64": {
           "reason": "No cp312 / Windows wheel; compile with MSVC. The shared runner workflow activates vcvars via milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4 before this step runs, so the env (INCLUDE / LIB / LIBPATH / PATH plus DISTUTILS_USE_SDK) is in scope when pip wheel invokes setuptools.",
           "buildRequires": ["setuptools", "wheel"]
+        }
+      },
+      "hdbscan": {
+        "linux-aarch64": {
+          "reason": "No cp312 / Linux ARM64 wheel on PyPI for hdbscan 0.8.44 (wheels exist for linux-x64, macOS universal2, and win-x64); compile the Cython sources on the native ARM runner.",
+          "buildRequires": ["setuptools", "wheel", "Cython", "numpy"]
         }
       }
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `hdbscan==0.8.44` (scikit-learn-contrib HDBSCAN) to the Python 3.12.10 runenv, enabling density-based clustering with out-of-sample assignment for the embedding-clustering block's large-dataset path. A platform-specific `buildWheel` entry is included for `linux-aarch64`, where no prebuilt cp312 wheel exists on PyPI.

- **`hdbscan==0.8.44` added to `dependencies`** in `python-3.12.10/config.json`, placed after `umap-learn` in the dependency list.
- **`buildWheel` entry for `linux-aarch64`** added with `Cython` and `numpy` as build requirements, compiling from Cython sources on the native ARM runner.
- **Two changeset files** (`calm-crabs-type.md` and `add-hdbscan-python-3-12-10.md`) both target the same package with a `patch` bump; the duplicate will cause a double version bump and needs to be removed.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: the duplicate changeset will inflate the version number, and the prebuilt wheels need to be verified against NumPy 2.x before this lands in a runenv used by downstream blocks.

The duplicate changeset causes a concrete, reproducible double version bump the moment changesets are consumed. Additionally, hdbscan 0.8.44 ships Cython-compiled prebuilt wheels and the runenv pins numpy==2.2.6; if those wheels were linked against NumPy 1.x's C ABI, every non-ARM platform will get a hard import failure at runtime.

python-3.12.10/config.json warrants a NumPy 2.x ABI check for hdbscan prebuilt wheels; .changeset/calm-crabs-type.md must be deleted.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Adds hdbscan==0.8.44 to dependencies and a linux-aarch64 buildWheel entry; prebuilt wheels on other platforms may be incompatible with numpy==2.2.6. |
| .changeset/add-hdbscan-python-3-12-10.md | Well-detailed changeset describing the hdbscan addition; this is the authoritative entry that should be kept. |
| .changeset/calm-crabs-type.md | Duplicate changeset for the same package/version bump as add-hdbscan-python-3-12-10.md; causes a double patch bump and should be deleted. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[hdbscan==0.8.44 added to dependencies] --> B{Platform?}
    B -->|linux-x64| C[Use prebuilt cp312 wheel from PyPI]
    B -->|macOS universal2| C
    B -->|win-x64| C
    B -->|linux-aarch64| D[No cp312 wheel on PyPI]
    D --> E[buildWheel triggered]
    E --> F[Build requires: setuptools, wheel, Cython, numpy]
    F --> G[Compile Cython sources on native ARM runner]
    C --> H{NumPy 2.x ABI check}
    H -->|Wheel built vs NumPy 1.x| I[⚠️ Runtime ImportError]
    H -->|Wheel built vs NumPy 2.x| J[✅ Works with numpy==2.2.6]
    G --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[hdbscan==0.8.44 added to dependencies] --> B{Platform?}
    B -->|linux-x64| C[Use prebuilt cp312 wheel from PyPI]
    B -->|macOS universal2| C
    B -->|win-x64| C
    B -->|linux-aarch64| D[No cp312 wheel on PyPI]
    D --> E[buildWheel triggered]
    E --> F[Build requires: setuptools, wheel, Cython, numpy]
    F --> G[Compile Cython sources on native ARM runner]
    C --> H{NumPy 2.x ABI check}
    H -->|Wheel built vs NumPy 1.x| I[⚠️ Runtime ImportError]
    H -->|Wheel built vs NumPy 2.x| J[✅ Works with numpy==2.2.6]
    G --> J
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.changeset%2Fcalm-crabs-type.md%3A1-5%0A**Duplicate%20changeset%20causes%20a%20double%20patch%20bump**%0A%0ABoth%20%60.changeset%2Fcalm-crabs-type.md%60%20and%20%60.changeset%2Fadd-hdbscan-python-3-12-10.md%60%20target%20the%20same%20package%20%28%60%40platforma-open%2Fmilaboratories.runenv-python-3.12.10%60%29%20with%20a%20%60patch%60%20bump.%20When%20the%20changeset%20tooling%20processes%20the%20PR%2C%20it%20will%20apply%20two%20independent%20patch%20version%20bumps%20instead%20of%20one.%20The%20detailed%20changeset%20%28%60add-hdbscan-python-3-12-10.md%60%29%20is%20the%20authoritative%20one%3B%20this%20file%20should%20be%20deleted%20before%20merging.%0A%0A%23%23%23%20Issue%202%20of%202%0Apython-3.12.10%2Fconfig.json%3A15%0A**hdbscan%200.8.44%20prebuilt%20wheels%20may%20be%20incompatible%20with%20NumPy%202.x**%0A%0A%60hdbscan%3D%3D0.8.44%60%20ships%20prebuilt%20cp312%20wheels%20for%20linux-x64%2C%20macOS%20universal2%2C%20and%20win-x64.%20If%20those%20wheels%20were%20compiled%20against%20NumPy%201.x%2C%20they%20will%20fail%20to%20import%20at%20runtime%20against%20%60numpy%3D%3D2.2.6%60%20because%20NumPy%202.0%20introduced%20ABI-breaking%20changes%20for%20Cython%20extensions%20that%20used%20the%20old%20C%20API.%20The%20linux-aarch64%20path%20builds%20from%20source%20%28fine%20%E2%80%94%20it%20will%20compile%20against%20the%202.2.6%20headers%29%2C%20but%20the%20three%20prebuilt-wheel%20platforms%20are%20at%20risk.%20It%20is%20worth%20verifying%20that%20the%20PyPI%20wheels%20for%20hdbscan%200.8.44%20were%20built%20with%20%60NPY_TARGET_VERSION%60%20targeting%20NumPy%202.x%20before%20merging.%0A%0A&repo=platforma-open%2Frunenv-python-3&pr=99&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.changeset/calm-crabs-type.md:1-5
**Duplicate changeset causes a double patch bump**

Both `.changeset/calm-crabs-type.md` and `.changeset/add-hdbscan-python-3-12-10.md` target the same package (`@platforma-open/milaboratories.runenv-python-3.12.10`) with a `patch` bump. When the changeset tooling processes the PR, it will apply two independent patch version bumps instead of one. The detailed changeset (`add-hdbscan-python-3-12-10.md`) is the authoritative one; this file should be deleted before merging.

### Issue 2 of 2
python-3.12.10/config.json:15
**hdbscan 0.8.44 prebuilt wheels may be incompatible with NumPy 2.x**

`hdbscan==0.8.44` ships prebuilt cp312 wheels for linux-x64, macOS universal2, and win-x64. If those wheels were compiled against NumPy 1.x, they will fail to import at runtime against `numpy==2.2.6` because NumPy 2.0 introduced ABI-breaking changes for Cython extensions that used the old C API. The linux-aarch64 path builds from source (fine — it will compile against the 2.2.6 headers), but the three prebuilt-wheel platforms are at risk. It is worth verifying that the PyPI wheels for hdbscan 0.8.44 were built with `NPY_TARGET_VERSION` targeting NumPy 2.x before merging.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/runenv-python-3/commit/a8fb7d8608a2790bb1486aeda175fa7dd0d0ba33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42651073)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->