### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/swift-rabbits-attack.md
+++ b/.changeset/swift-rabbits-attack.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.53",
+      "polars-pf==1.1.54",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `polars-pf` package pin in the Python 3.12.10 run environment from `1.1.53` to `1.1.54`, paired with a changeset entry that triggers a patch release of the enclosing `runenv-python-3.12.10` package.

- **`polars-pf`** — A proprietary MiLaLaboratories extension to Polars that provides PFrames (Platforma Frames) data-format support. Version `1.1.54` is pinned alongside the other Polars-family packages (`polars-lts-cpu`, `polars-ds-lts-cpu`, `polars-hash-lts-cpu`), all of which remain unchanged at their current pins.
- **Changeset** — `swift-rabbits-attack.md` correctly declares a `patch` bump for `@platforma-open/milaboratories.runenv-python-3.12.10`, consistent with a dependency-only update.

**Touched Terms:**

| Term | Definition | Change |
|---|---|---|
| `polars-pf` | Proprietary MiLaLaboratories Polars extension enabling PFrames (Platforma Frames) columnar data interchange within the Platforma ecosystem | Upgraded `1.1.53 → 1.1.54` |
| `PFrames` | Platforma Frames — the typed columnar data-transfer format used across Platforma workflows and run environments | Indirectly updated; the `polars-pf` package is its Python implementation |
| `dependencies` (in `config.json`) | The pinned list of Python packages that are installed into the Python 3.12.10 run environment at build time | One entry changed (`polars-pf`) |
| `patch` (changeset type) | Semver patch bump — a backward-compatible fix or update that does not add or remove public API | Declared in the new changeset file for this PR |
| `@platforma-open/milaboratories.runenv-python-3.12.10` | The Platforma package identifier for the Python 3.12.10 run environment distributed to workflow nodes | Receives a patch release triggered by this changeset |

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A single dependency pin update with a matching changeset — straightforward and low risk.

The change touches exactly one package pin (polars-pf 1.1.53 → 1.1.54) and a correctly scoped changeset. No configuration structure is altered, no other packages are affected, and the version step is a minor patch increment within a well-established internal package family.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Bumps polars-pf dependency from 1.1.53 to 1.1.54 — a single-line patch version increment with no other changes. |
| .changeset/swift-rabbits-attack.md | New changeset file correctly marking the runenv-python-3.12.10 package for a patch release, matching the scope of the dependency bump. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant Changeset as Changeset File
    participant Config as config.json
    participant PyPI as PyPI
    participant RunEnv as runenv-python-3.12.10

    Dev->>Changeset: Add swift-rabbits-attack.md (patch bump)
    Dev->>Config: Update polars-pf 1.1.53 → 1.1.54
    Config->>PyPI: "Resolve polars-pf==1.1.54"
    PyPI-->>Config: "Wheel downloaded & pinned"
    Changeset->>RunEnv: "Trigger patch release of @platforma-open/milaboratories.runenv-python-3.12.10"
    RunEnv-->>Dev: New run environment image published with updated PFrames support
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant Changeset as Changeset File
    participant Config as config.json
    participant PyPI as PyPI
    participant RunEnv as runenv-python-3.12.10

    Dev->>Changeset: Add swift-rabbits-attack.md (patch bump)
    Dev->>Config: Update polars-pf 1.1.53 → 1.1.54
    Config->>PyPI: "Resolve polars-pf==1.1.54"
    PyPI-->>Config: "Wheel downloaded & pinned"
    Changeset->>RunEnv: "Trigger patch release of @platforma-open/milaboratories.runenv-python-3.12.10"
    RunEnv-->>Dev: New run environment image published with updated PFrames support
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/e3d044eb3a63331a80a32adaf75c4a2985519766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43078016)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->