### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/pink-pumas-clap.md
+++ b/.changeset/pink-pumas-clap.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10': patch
+---
+
+PFrames bump

--- a/python-3.12.10/config.json
+++ b/python-3.12.10/config.json
@@ -6,7 +6,7 @@
       "polars-lts-cpu==1.33.1",
       "polars-ds-lts-cpu==0.10.2",
       "polars-hash-lts-cpu==0.5.5",
-      "polars-pf==1.1.55",
+      "polars-pf==1.1.56",
       "scipy==1.15.3",
       "scikit-learn==1.6.1",
       "parasail==1.3.4",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `polars-pf` package from `1.1.55` to `1.1.56` in the Python 3.12.10 runtime environment config and adds the corresponding changeset entry marking it as a patch release.

- **`polars-pf` version bump** (`python-3.12.10/config.json`): Single dependency line changed from `polars-pf==1.1.55` to `polars-pf==1.1.56`. All other pinned packages (polars, pandas, torch, etc.) remain unchanged.
- **Changeset** (`.changeset/pink-pumas-clap.md`): New file recording a `patch`-level release for `@platforma-open/milaboratories.runenv-python-3.12.10` with the description "PFrames bump".

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single patch-version dependency bump with a matching changeset.

The change is limited to one pinned dependency line in config.json: polars-pf moves from 1.1.55 to 1.1.56, a patch release. The corresponding changeset is correctly typed as patch. No logic, no scripts, no schema changes are involved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10/config.json | Bumps polars-pf dependency from 1.1.55 to 1.1.56 (patch version); no other changes. |
| .changeset/pink-pumas-clap.md | New changeset entry recording the polars-pf bump as a patch release for the runenv-python-3.12.10 package. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["python-3.12.10/config.json"] -->|"polars-pf dependency"| B["polars-pf==1.1.55 → 1.1.56"]
    C[".changeset/pink-pumas-clap.md"] -->|"records"| D["patch release\n@platforma-open/milaboratories.runenv-python-3.12.10"]
    B --> E["Runtime environment rebuilt\nwith updated PFrames"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["python-3.12.10/config.json"] -->|"polars-pf dependency"| B["polars-pf==1.1.55 → 1.1.56"]
    C[".changeset/pink-pumas-clap.md"] -->|"records"| D["patch release\n@platforma-open/milaboratories.runenv-python-3.12.10"]
    B --> E["Runtime environment rebuilt\nwith updated PFrames"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/platforma-open/runenv-python-3/commit/f5643fa33a0de856543f3536f7ef8fd59897b367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45602231)</sub>

<!-- /greptile_comment -->