### PR TITLE
Silence cudf ptxcompiler numba-codegen probe in RAPIDS runenv

### DIFF
--- a/.changeset/silence-ptxcompiler-probe.md
+++ b/.changeset/silence-ptxcompiler-probe.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.runenv-python-3.12.10-rapids": patch
+---
+
+Silence the cudf ptxcompiler numba-codegen probe. Setting `PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED=0` skips the import-time subprocess that fails to load `libcudart.so` and prints a misleading `OSError` traceback plus `Not patching Numba` on every run. cuML/CuPy are unaffected — the probe already defaulted to not patching.

--- a/python-3.12.10-rapids/package.json
+++ b/python-3.12.10-rapids/package.json
@@ -26,7 +26,8 @@
               "NVIDIA_VISIBLE_DEVICES=all",
               "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
               "LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib",
-              "PATH=/usr/local/nvidia/bin:${PATH}"
+              "PATH=/usr/local/nvidia/bin:${PATH}",
+              "PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED=0"
             ],
             "roots": {
               "linux-x64": "./pydist/linux-x64",


### PR DESCRIPTION
## What

Adds `PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED=0` to the `python-3.12.10-rapids` runenv `envVars`.

## Why

Every GPU block on this runenv logs a misleading error on startup:

```
cudf/utils/_ptxcompiler.py: UserWarning: Error getting driver and runtime versions:
OSError: libcudart.so: cannot open shared object file: No such file or directory
Not patching Numba
```

On import, cudf spawns a subprocess to probe the CUDA runtime version. `numba_cuda 0.4.0` (pinned by cudf/cuml 25.04) only discovers CUDA libs via conda / `CUDA_HOME` / `/usr/local/cuda` — all conda-gated — so in this pip-based portable-python runenv it falls back to `ctypes.CDLL("libcudart.so")` (unversioned), which the pip wheel doesn't ship (only `libcudart.so.12`). The probe fails, and the traceback surfaces in block error reports where it masks the real failure.

The env var makes cudf skip the probe entirely (`check_disabled_in_env()` returns `True` for `0`).

## Safety

No loss of GPU functionality. Verified on a real GPU pod (block image, RTX 4000) that with the probe silenced, cuML PCA + UMAP on GPU still run. The probe only gates a numba codegen patch that was already being skipped, and no block uses in-process numba-CUDA (cuML/cuDF/cuPy use their own bundled native libs).

Note: fully restoring in-process numba-CUDA lib discovery would require baking a `libcudart.so` symlink into the downstream image build (where the wheels install) or a RAPIDS-version bump — out of scope and of no functional benefit to current GPU blocks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses a misleading import-time CUDA compatibility probe in the Python 3.12.10 RAPIDS run environment.
- `PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED`: An environment variable controlling whether cuDF checks if Numba codegen needs patching; the PR sets it to `0`, disabling the probe.
- `envVars`: Runtime environment variables attached to a run-environment artifact; the PR adds the PTX compiler setting to the RAPIDS artifact.
- `ptxcompiler probe`: A cuDF import-time compatibility check that queries CUDA driver and runtime versions; the PR prevents it from running.
- `RAPIDS runenv`: The packaged Python environment containing GPU-oriented RAPIDS dependencies; its package receives a patch changeset for this configuration update.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change uses the existing run-environment variable format to disable a probe that already falls back to not applying the Numba patch when CUDA runtime discovery fails.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-rapids/package.json | Adds the fixed PTX compiler environment setting to suppress the failing compatibility probe; no actionable defect was identified. |
| .changeset/silence-ptxcompiler-probe.md | Declares a patch release and documents the reason and expected effect of disabling the probe. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Silence cudf ptxcompiler numba-codegen p..."](https://github.com/platforma-open/runenv-python-3/commit/b210ec150e807676ac5b50bccab66b019908a5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46990998)</sub>

<!-- /greptile_comment -->