### PR TITLE
MILABL-6766 Fix rapids env issues for non docker envs

### DIFF
--- a/.changeset/fix-rapids-path-expression.md
+++ b/.changeset/fix-rapids-path-expression.md
@@ -1,0 +1,11 @@
+---
+'@platforma-open/milaboratories.runenv-python-3.12.10-rapids': patch
+---
+
+Fix the RAPIDS runenv `PATH` env var breaking every non-docker run: use `$PATH` instead of `${PATH}`.
+`envVars` feeds two consumers with different syntaxes. The Dockerfile generator emits each entry as an `ENV` line, where Docker expands both `${PATH}` and `$PATH` at build time. The native (venv) path renders each entry through the backend's expr-lang renderer, whose scanner regex `{.*?[^\\]}` matches the `{PATH}` inside `${PATH}` and fails with `cannot evaluate expression: "PATH" (variable is not defined)` — rejecting the venv-creation RunCommand, so any block on this runenv failed on a local/desktop backend while docker-backed backends were fine.
+`$PATH` carries no braces, so it expands correctly in the Dockerfile and is passed through literally on the native path, where the backend already appends the host `PATH` after any `PATH` entry in `envVars`.
+
+Add `pyarrow==19.0.1` to the RAPIDS runenv.
+Blocks on this runenv install their `requirements.txt` with `pip --no-index --find-links <runenv packages>`, so a requirement the runenv does not ship cannot resolve. `pyarrow` was never declared here (every sibling runenv declares it), so any block importing it failed with `No matching distribution found for pyarrow` on every platform where the `cu12` packages are skipped — macOS, Windows and linux-aarch64. On linux-x64 it resolved only incidentally, as a transitive dependency of `cudf-cu12`.
+Version is capped by RAPIDS: `cudf-cu12==25.4.0` requires `pyarrow>=14.0.0,<20.0.0a0` (plus `!=17.0.0` on aarch64), making 19.0.1 the highest usable release. That is why it differs from the 21.0.0 / 24.0.0 pinned by the non-RAPIDS runenvs. cp312 wheels exist for all five target platforms.

--- a/python-3.12.10-rapids/config.json
+++ b/python-3.12.10-rapids/config.json
@@ -12,6 +12,7 @@
       "numpy==2.0.2",
       "scikit-learn==1.7.2",
       "scipy==1.16.2",
+      "pyarrow==19.0.1",
       "umap-learn==0.5.7",
       "torch==2.7.0",
       "cudf-cu12==25.4.0",

--- a/python-3.12.10-rapids/package.json
+++ b/python-3.12.10-rapids/package.json
@@ -26,7 +26,7 @@
               "NVIDIA_VISIBLE_DEVICES=all",
               "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
               "LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib",
-              "PATH=/usr/local/nvidia/bin:${PATH}",
+              "PATH=/usr/local/nvidia/bin:$PATH",
               "PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED=0"
             ],
             "roots": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs RAPIDS environment creation on native backends by avoiding expression-renderer interpretation of `${PATH}`, and explicitly packages a RAPIDS-compatible PyArrow release for targets where CUDA packages are skipped.

- **RAPIDS runenv** — the Python environment containing NVIDIA RAPIDS libraries; its PATH declaration now uses `$PATH` so native environment rendering does not interpret `{PATH}` as an undefined expression.
- **`envVars`** — environment-variable declarations shared by Docker and native runenv consumers; the PATH entry changes from `${PATH}` to `$PATH`.
- **PyArrow** — Python bindings for Apache Arrow; version 19.0.1 is added as a direct packaged dependency for all configured targets.
- **Package skip rules** — platform mappings that omit unsupported CUDA packages; they are unchanged, while the newly direct PyArrow dependency remains available on non-CUDA targets.
- **Changeset** — release metadata describing a package update; a patch changeset documents both fixes and their compatibility rationale.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect established.

The PATH syntax avoids the documented native expression-renderer failure, and the added PyArrow version satisfies the documented RAPIDS constraint while targeting all configured platforms.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| python-3.12.10-rapids/package.json | Replaces brace-based PATH expansion with `$PATH` to prevent native expression-rendering failures while retaining Docker expansion. |
| python-3.12.10-rapids/config.json | Adds the RAPIDS-compatible `pyarrow==19.0.1` dependency across the runenv’s configured targets. |
| .changeset/fix-rapids-path-expression.md | Documents the native PATH-rendering failure, missing PyArrow package, platform impact, and version-selection rationale. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20platforma-open%2Frunenv-python-3%20PR%20%23104%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=platforma-open%2Frunenv-python-3&pr=104&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["MILABL-6766 Fix rapids env issues for no..."](https://github.com/platforma-open/runenv-python-3/commit/93653068b6744c01d2cbaa8ea1b92fdea3c69d46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52944234)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->